### PR TITLE
Plot retained log-likelihood trace

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AddiVortes
 Title: (Bayesian) Additive Voronoi Tessellations
-Version: 0.6.3
+Version: 0.6.4
 Authors@R: 
     c(person("Adam", "Stone", , "adam.stone2@durham.ac.uk",
              role = c("aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # AddiVortes News
 
+## AddiVortes 0.6.4
+
+* Corrected the log-likelihood trace in `traceplots()` so it now shows the
+  retained-state log-likelihood component at the end of each MCMC iteration,
+  rather than the average proposal log-likelihood-ratio component evaluated
+  during the sweep.
+
 ## AddiVortes 0.6.3
 
 * `traceplots()` now includes the burn-in period in its MCMC traces and colours

--- a/R/AddiVortesFit.R
+++ b/R/AddiVortesFit.R
@@ -650,8 +650,8 @@ traceplots <- function(x, ...) {
 #' Displays four MCMC trace plots for a fitted `AddiVortes` object:
 #' the average number of centres per tessellation, the standard deviation
 #' of the number of centres per tessellation, the average number of dimensions
-#' used per tessellation, and the log-likelihood component used in the
-#' acceptance ratio.
+#' used per tessellation, and the retained-state log-likelihood component whose
+#' differences form the likelihood part of the acceptance ratio.
 #'
 #' @param x An object of class `AddiVortes`, typically the result of a
 #'   call to `AddiVortes()`.
@@ -670,8 +670,8 @@ traceplots <- function(x, ...) {
 #'     number of centres per tessellation.
 #'   \item \strong{Average Dimensions}: Average number of active dimensions used
 #'     per tessellation.
-#'   \item \strong{Log Likelihood}: Average log-likelihood component used in the
-#'     tessellation acceptance ratios during each MCMC iteration.
+#'   \item \strong{Log Likelihood}: Average retained-state log-likelihood
+#'     component at the end of each MCMC iteration.
 #' }
 #'
 #' @importFrom graphics plot abline legend par text

--- a/man/traceplots.AddiVortes.Rd
+++ b/man/traceplots.AddiVortes.Rd
@@ -22,8 +22,8 @@ This function is called for its side effect of creating plots and returns
 Displays four MCMC trace plots for a fitted \code{AddiVortes} object:
 the average number of centres per tessellation, the standard deviation
 of the number of centres per tessellation, the average number of dimensions
-used per tessellation, and the log-likelihood component used in the
-acceptance ratio.
+used per tessellation, and the retained-state log-likelihood component whose
+differences form the likelihood part of the acceptance ratio.
 }
 \details{
 The four trace plots are:
@@ -33,8 +33,8 @@ The four trace plots are:
 number of centres per tessellation.
 \item \strong{Average Dimensions}: Average number of active dimensions used
 per tessellation.
-\item \strong{Log Likelihood}: Average log-likelihood component used in the
-tessellation acceptance ratios during each MCMC iteration.
+\item \strong{Log Likelihood}: Average retained-state log-likelihood component
+at the end of each MCMC iteration.
 }
 }
 \examples{

--- a/man/traceplots.AddiVortes.Rd
+++ b/man/traceplots.AddiVortes.Rd
@@ -33,8 +33,8 @@ The four trace plots are:
 number of centres per tessellation.
 \item \strong{Average Dimensions}: Average number of active dimensions used
 per tessellation.
-\item \strong{Log Likelihood}: Average retained-state log-likelihood component
-at the end of each MCMC iteration.
+\item \strong{Log Likelihood}: Average retained-state log-likelihood
+component at the end of each MCMC iteration.
 }
 }
 \examples{

--- a/src/addi_vortes_code.cpp
+++ b/src/addi_vortes_code.cpp
@@ -530,10 +530,26 @@ static void aggregate_residuals(
 
 struct AcceptanceComponents {
   double logAlpha;
-  double logLikelihood;
 };
 
-// Compute the log acceptance probability and its log-likelihood component.
+// Compute the part of the marginal log-likelihood used in the tessellation
+// acceptance ratio for one retained/proposed tessellation state. Constants that
+// cancel in the acceptance ratio are omitted.
+static double tessellation_log_likelihood_component(
+    const std::vector<double>& R, const std::vector<int>& n,
+    double sigmaSquared, double sigmaSquaredMu) {
+
+  double sum_log = 0.0, sum_R = 0.0;
+  for (int k = 0; k < (int)n.size(); k++) {
+    double den = n[k] * sigmaSquaredMu + sigmaSquared;
+    sum_log += log(den);
+    sum_R   += (R[k] * R[k]) / den;
+  }
+
+  return -0.5 * sum_log + (sigmaSquaredMu / (2.0 * sigmaSquared)) * sum_R;
+}
+
+// Compute the log acceptance probability and its log-likelihood-ratio component.
 static AcceptanceComponents log_acceptance_components(
     const std::vector<double>& R_old, const std::vector<int>& n_old,
     const std::vector<double>& R_new, const std::vector<int>& n_new,
@@ -542,21 +558,11 @@ static AcceptanceComponents log_acceptance_components(
     double omega, double lambdaRate, int p,
     const std::string& mod) {
 
-  double sum_log_old = 0.0, sum_R_old = 0.0;
-  for (int k = 0; k < (int)n_old.size(); k++) {
-    double den = n_old[k] * sigmaSquaredMu + sigmaSquared;
-    sum_log_old += log(den);
-    sum_R_old   += (R_old[k] * R_old[k]) / den;
-  }
-  double sum_log_new = 0.0, sum_R_new = 0.0;
-  for (int k = 0; k < (int)n_new.size(); k++) {
-    double den = n_new[k] * sigmaSquaredMu + sigmaSquared;
-    sum_log_new += log(den);
-    sum_R_new   += (R_new[k] * R_new[k]) / den;
-  }
-
-  double log_lik = 0.5 * (sum_log_old - sum_log_new) +
-    (sigmaSquaredMu / (2.0 * sigmaSquared)) * (sum_R_new - sum_R_old);
+  double old_log_lik = tessellation_log_likelihood_component(
+    R_old, n_old, sigmaSquared, sigmaSquaredMu);
+  double new_log_lik = tessellation_log_likelihood_component(
+    R_new, n_new, sigmaSquared, sigmaSquaredMu);
+  double log_lik = new_log_lik - old_log_lik;
 
   const double prob_eps = 1e-10;
   double prob = std::min(1.0 - prob_eps, std::max(0.0, omega / p));
@@ -595,7 +601,7 @@ static AcceptanceComponents log_acceptance_components(
   }
   // "Change" and "Swap": log(TessStructure * TransitionRatio) = 0
 
-  return {acc, log_lik};
+  return {acc};
 }
 
 // Sample mu values for all centres of tessellation j.
@@ -932,9 +938,6 @@ extern "C" {
       double rate  = (nu * lambda + sum_sq) / 2.0;
       sigmaSquared = 1.0 / rgamma(shape, 1.0 / rate);
 
-      double iterLogLikSum = 0.0;
-      int iterLogLikCount = 0;
-
       for (int j = 0; j < m; j++) {
 
         // Update sumAllTess to exclude tessellation j
@@ -999,8 +1002,6 @@ extern "C" {
             sigmaSquared, sigSqMu,
             omega, lambdaRate, p,
             prop.mod);
-          iterLogLikSum += acc.logLikelihood;
-          iterLogLikCount++;
           accepted = (log(unif_rand()) < acc.logAlpha);
         }
 
@@ -1028,9 +1029,24 @@ extern "C" {
 
       double meanCenters = 0.0;
       double meanDims = 0.0;
+      double retainedLogLikSum = 0.0;
       for (int j = 0; j < m; j++) {
         meanCenters += tess_nC[j];
         meanDims += tess_d[j];
+
+        // Recompute partial residuals from the final retained state after the
+        // full sweep, so the trace reflects what remains at iteration end.
+        std::vector<double> R_retained(tess_nC[j], 0.0);
+        std::vector<int> n_retained(tess_nC[j], 0);
+        for (int obs = 0; obs < n; obs++) {
+          int cell = curIdx[j][obs];
+          double tessContribution = pred[j][cell];
+          double r = yScaled[obs] - (sumAllTess[obs] - tessContribution);
+          R_retained[cell] += r;
+          n_retained[cell]++;
+        }
+        retainedLogLikSum += tessellation_log_likelihood_component(
+          R_retained, n_retained, sigmaSquared, sigSqMu);
       }
       meanCenters /= m;
       meanDims /= m;
@@ -1050,8 +1066,7 @@ extern "C" {
       REAL(outTraceAvgCenters)[traceIdx] = meanCenters;
       REAL(outTraceSdCenters)[traceIdx] = sdCenters;
       REAL(outTraceAvgDims)[traceIdx] = meanDims;
-      REAL(outTraceLogLik)[traceIdx] =
-        (iterLogLikCount > 0) ? (iterLogLikSum / iterLogLikCount) : NA_REAL;
+      REAL(outTraceLogLik)[traceIdx] = retainedLogLikSum / m;
 
       // Store posterior sample (post burn-in, respecting thinning)
       if (iter > burnIn && (iter - burnIn) % thinning == 0) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Correct the `traceplots()` log-likelihood trace to use the retained end-of-iteration state.
- Keep the acceptance-ratio calculation as the difference between proposed and current state log-likelihood components, but stop plotting proposal-ratio components.
- Bump the package version to 0.6.4 and document the correction in `NEWS.md`.

## What was wrong
The accepted 0.6.3 implementation plotted the average proposal log-likelihood-ratio component evaluated during each tessellation proposal. That included rejected proposals and was not tied to the parameter set retained at the end of the MCMC iteration.

## Verification
- `git diff --check`
- `git diff main...HEAD --check`
- Source scan confirmed the trace is now written from `retainedLogLikSum / m` after the full MCMC iteration state is retained.
- Could not run `Rscript -e 'testthat::test_dir("tests/testthat")'`: `Rscript` is not available in this cloud image.
- Could not run `g++ -std=c++20 -fsyntax-only src/addi_vortes_code.cpp`: R headers are not available in this cloud image (`R.h` missing).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97dabcbe-162f-4d8e-b31e-30113358b04f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97dabcbe-162f-4d8e-b31e-30113358b04f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

