### PR TITLE
Fix MH acceptance ratio calculations

### DIFF
--- a/R/0_AcceptanceProbability.R
+++ b/R/0_AcceptanceProbability.R
@@ -51,6 +51,40 @@ acceptanceProbability <- function(R_ijOld, n_ijOld,
   prob_eps <- 1e-10 # keep prob strictly below 1 to avoid 0/0 in dbinom
   prob <- min(1 - prob_eps, max(0, Omega / NumCovariates))
 
+  addDimensionProbability <- function(dCurrent) {
+    if (dCurrent >= NumCovariates) {
+      return(0)
+    }
+    if (dCurrent == 1) {
+      return(0.4)
+    }
+    0.2
+  }
+
+  removeDimensionProbability <- function(dCurrent) {
+    if (dCurrent <= 1) {
+      return(0)
+    }
+    if (dCurrent == NumCovariates) {
+      return(0.4)
+    }
+    0.2
+  }
+
+  addCentreProbability <- function(cCurrent) {
+    if (cCurrent == 1) {
+      return(0.4)
+    }
+    0.2
+  }
+
+  removeCentreProbability <- function(cCurrent) {
+    if (cCurrent > 1) {
+      return(0.2)
+    }
+    0
+  }
+
   LogLikelihoodRatio <- 0.5 * (log(prod(n_ijOld * SigmaSquaredMu +
     SigmaSquared)) -
     log(prod(n_ijNew * SigmaSquaredMu +
@@ -60,45 +94,41 @@ acceptanceProbability <- function(R_ijOld, n_ijOld,
         sum((R_ijOld^2) / (n_ijOld * SigmaSquaredMu + SigmaSquared))))
 
   if (Modification == "AD") {
-    TessStructure <- (dbinom(d - 1, NumCovariates - 1, prob)) /
-      (dbinom(d - 2, NumCovariates - 1, prob) *
-        (NumCovariates - d + 1))
-    TransitionRatio <- (NumCovariates - d + 1) / d
-    AcceptanceProb <- LogLikelihoodRatio + log(TessStructure) +
-      log(TransitionRatio)
-    if (length(dim_j_star) == 1) {
-      AcceptanceProb <- AcceptanceProb + log(1 / 2)
-    } else if (length(dim_j_star) == NumCovariates - 1) {
-      AcceptanceProb <- AcceptanceProb + log(2)
-    }
+    dOld <- d - 1
+    AcceptanceProb <- LogLikelihoodRatio +
+      2 * log(NumCovariates - dOld) -
+      log(dOld) -
+      log(d) +
+      log(prob) -
+      log1p(-prob) +
+      log(removeDimensionProbability(d)) -
+      log(addDimensionProbability(dOld))
   } else if (Modification == "RD") {
-    TessStructure <- (dbinom(d - 1, NumCovariates, prob) *
-      (NumCovariates - d)) /
-      (dbinom(d, NumCovariates, prob))
-    TransitionRatio <- (d + 1) / (NumCovariates - d)
-    AcceptanceProb <- LogLikelihoodRatio + log(TessStructure) +
-      log(TransitionRatio)
-    if (length(dim_j_star) == NumCovariates) {
-      AcceptanceProb <- AcceptanceProb + log(1 / 2)
-    } else if (length(dim_j_star) == 2) {
-      AcceptanceProb <- AcceptanceProb + log(2)
-    }
+    dOld <- d + 1
+    AcceptanceProb <- LogLikelihoodRatio +
+      log(dOld) +
+      log(d) -
+      2 * log(NumCovariates - d) +
+      log1p(-prob) -
+      log(prob) +
+      log(addDimensionProbability(d)) -
+      log(removeDimensionProbability(dOld))
   } else if (Modification == "AC") {
-    TessStructure <- dpois(cStar - 1, LambdaRate) / dpois(cStar - 2, LambdaRate)
-    TransitionRatio <- 1 / cStar
-    AcceptanceProb <- LogLikelihoodRatio + log(TessStructure) +
-      log(TransitionRatio) + 0.5 * log(SigmaSquared)
-    if (cStar == 1) {
-      AcceptanceProb <- AcceptanceProb + log(1 / 2)
-    }
+    cOld <- length(n_ijOld)
+    AcceptanceProb <- LogLikelihoodRatio +
+      log(LambdaRate) -
+      2 * log(cStar) +
+      log(removeCentreProbability(cStar)) -
+      log(addCentreProbability(cOld)) +
+      0.5 * log(SigmaSquared)
   } else if (Modification == "RC") {
-    TessStructure <- dpois(cStar - 1, LambdaRate) / dpois(cStar, LambdaRate)
-    TransitionRatio <- cStar + 1
-    AcceptanceProb <- LogLikelihoodRatio + log(TessStructure) +
-      log(TransitionRatio) - 0.5 * log(SigmaSquared)
-    if (cStar == 2) {
-      AcceptanceProb <- AcceptanceProb + log(2)
-    }
+    cOld <- length(n_ijOld)
+    AcceptanceProb <- LogLikelihoodRatio +
+      2 * log(cOld) -
+      log(LambdaRate) +
+      log(addCentreProbability(cStar)) -
+      log(removeCentreProbability(cOld)) -
+      0.5 * log(SigmaSquared)
   } else if (Modification == "Change") {
     TessStructure <- 1
     TransitionRatio <- 1

--- a/src/addi_vortes_code.cpp
+++ b/src/addi_vortes_code.cpp
@@ -532,6 +532,24 @@ struct AcceptanceComponents {
   double logAlpha;
 };
 
+static double add_dimension_probability(int d, int p) {
+  if (d >= p) return 0.0;
+  return (d == 1) ? 0.4 : 0.2;
+}
+
+static double remove_dimension_probability(int d, int p) {
+  if (d <= 1) return 0.0;
+  return (d == p) ? 0.4 : 0.2;
+}
+
+static double add_centre_probability(int nC) {
+  return (nC == 1) ? 0.4 : 0.2;
+}
+
+static double remove_centre_probability(int nC) {
+  return (nC > 1) ? 0.2 : 0.0;
+}
+
 // Compute the part of the marginal log-likelihood used in the tessellation
 // acceptance ratio for one retained/proposed tessellation state. Constants that
 // cancel in the acceptance ratio are omitted.
@@ -553,7 +571,7 @@ static double tessellation_log_likelihood_component(
 static AcceptanceComponents log_acceptance_components(
     const std::vector<double>& R_old, const std::vector<int>& n_old,
     const std::vector<double>& R_new, const std::vector<int>& n_new,
-    int d_new, int nC_new,
+    int d_old, int d_new, int nC_old, int nC_new,
     double sigmaSquared, double sigmaSquaredMu,
     double omega, double lambdaRate, int p,
     const std::string& mod) {
@@ -570,34 +588,38 @@ static AcceptanceComponents log_acceptance_components(
   double acc = log_lik;
 
   if (mod == "AD") {
-    double log_ts_tr = dbinom(d_new - 1, p - 1, prob, 1)
-                     - dbinom(d_new - 2, p - 1, prob, 1)
-                     - log((double)d_new);
+    double log_ts_tr = 2.0 * log((double)(p - d_old))
+                     - log((double)d_old)
+                     - log((double)d_new)
+                     + log(prob)
+                     - log1p(-prob)
+                     + log(remove_dimension_probability(d_new, p))
+                     - log(add_dimension_probability(d_old, p));
     acc += log_ts_tr;
-    if (d_new == 1)     acc += log(0.5);
-    else if (d_new == p - 1) acc += log(2.0);
 
   } else if (mod == "RD") {
-    double log_ts_tr = dbinom(d_new - 1, p, prob, 1)
-                     - dbinom(d_new,     p, prob, 1)
-                     + log((double)(d_new + 1));
+    double log_ts_tr = log((double)d_old)
+                     + log((double)d_new)
+                     - 2.0 * log((double)(p - d_new))
+                     + log1p(-prob)
+                     - log(prob)
+                     + log(add_dimension_probability(d_new, p))
+                     - log(remove_dimension_probability(d_old, p));
     acc += log_ts_tr;
-    if (d_new == p) acc += log(0.5);
-    else if (d_new == 2) acc += log(2.0);
 
   } else if (mod == "AC") {
-    double log_ts_tr = dpois(nC_new - 1, lambdaRate, 1)
-                     - dpois(nC_new - 2, lambdaRate, 1)
-                     - log((double)nC_new);
+    double log_ts_tr = log(lambdaRate)
+                     - 2.0 * log((double)nC_new)
+                     + log(remove_centre_probability(nC_new))
+                     - log(add_centre_probability(nC_old));
     acc += log_ts_tr + 0.5 * log(sigmaSquared);
-    if (nC_new == 1) acc += log(0.5);
 
   } else if (mod == "RC") {
-    double log_ts_tr = dpois(nC_new - 1, lambdaRate, 1)
-                     - dpois(nC_new,     lambdaRate, 1)
-                     + log((double)(nC_new + 1));
+    double log_ts_tr = 2.0 * log((double)nC_old)
+                     - log(lambdaRate)
+                     + log(add_centre_probability(nC_new))
+                     - log(remove_centre_probability(nC_old));
     acc += log_ts_tr - 0.5 * log(sigmaSquared);
-    if (nC_new == 2) acc += log(2.0);
   }
   // "Change" and "Swap": log(TessStructure * TransitionRatio) = 0
 
@@ -998,7 +1020,8 @@ extern "C" {
         if (!hasEmpty) {
           AcceptanceComponents acc = log_acceptance_components(
             R_old, n_old, R_new, n_new,
-            (int)prop.dim.size(), prop.nC,
+            tess_d[j], (int)prop.dim.size(),
+            tess_nC[j], prop.nC,
             sigmaSquared, sigSqMu,
             omega, lambdaRate, p,
             prop.mod);

--- a/tests/testthat/test-Overall.R
+++ b/tests/testthat/test-Overall.R
@@ -14,7 +14,7 @@ test_that("Simple AddiVortes fit 1", {
     InitialSigma = "Linear"
   )
 
-  expect_equal(round(results$inSampleRmse, 3), 0.591)
+  expect_equal(round(results$inSampleRmse, 3), 0.759)
 })
 
 test_that("Simple AddiVortes fit 2", {
@@ -32,7 +32,7 @@ test_that("Simple AddiVortes fit 2", {
   )
 
 
-  expect_equal(round(results$inSampleRmse, 3), 2.669)
+  expect_equal(round(results$inSampleRmse, 3), 2.542)
 })
 
 test_that("Simple AddiVortes fit 3", {
@@ -49,7 +49,7 @@ test_that("Simple AddiVortes fit 3", {
     InitialSigma = "Linear"
   )
 
-  expect_equal(round(results$inSampleRmse, 3), 1.142)
+  expect_equal(round(results$inSampleRmse, 3), 1.140)
 })
 
 test_that("Warning when p > n", {

--- a/tests/testthat/test-Quantile.R
+++ b/tests/testthat/test-Quantile.R
@@ -24,11 +24,11 @@ test_that("AddiVortes fit 1 with quantile check", {
   expect_true(all(predictions[, 1] <= predictions[, 2]))
   expect_equal(
     round(as.numeric(predictions[1, 2]), 3),
-    0.484
+    0.278
   )
   expect_equal(
     round(as.numeric(predictions[10, 1]), 3),
-    -0.024
+    0.025
   )
 })
 

--- a/tests/testthat/test-acceptanceProbability-ratios.R
+++ b/tests/testthat/test-acceptanceProbability-ratios.R
@@ -1,0 +1,282 @@
+log_likelihood_ratio_for_test <- function(R_old, n_old, R_new, n_new,
+                                          sigma_sq, sigma_mu) {
+  0.5 * (
+    log(prod(n_old * sigma_mu + sigma_sq)) -
+      log(prod(n_new * sigma_mu + sigma_sq))
+  ) +
+    (sigma_mu / (2 * sigma_sq)) *
+      (
+        sum((R_new^2) / (n_new * sigma_mu + sigma_sq)) -
+          sum((R_old^2) / (n_old * sigma_mu + sigma_sq))
+      )
+}
+
+add_dimension_probability_for_test <- function(d_current, p) {
+  if (d_current >= p) {
+    return(0)
+  }
+  if (d_current == 1) {
+    return(0.4)
+  }
+  0.2
+}
+
+remove_dimension_probability_for_test <- function(d_current, p) {
+  if (d_current <= 1) {
+    return(0)
+  }
+  if (d_current == p) {
+    return(0.4)
+  }
+  0.2
+}
+
+add_centre_probability_for_test <- function(c_current) {
+  if (c_current == 1) {
+    return(0.4)
+  }
+  0.2
+}
+
+remove_centre_probability_for_test <- function(c_current) {
+  if (c_current > 1) {
+    return(0.2)
+  }
+  0
+}
+
+expect_acceptance_ratio <- function(R_old, n_old, R_new, n_new,
+                                    tess_rows, dim_count, sigma_sq, sigma_mu,
+                                    modification, omega, lambda_rate,
+                                    p, expected) {
+  observed <- acceptanceProbability(
+    R_ijOld = R_old,
+    n_ijOld = n_old,
+    R_ijNew = R_new,
+    n_ijNew = n_new,
+    tess_j_star = matrix(0, nrow = tess_rows, ncol = dim_count),
+    dim_j_star = seq_len(dim_count),
+    SigmaSquared = sigma_sq,
+    Modification = modification,
+    SigmaSquaredMu = sigma_mu,
+    Omega = omega,
+    LambdaRate = lambda_rate,
+    NumCovariates = p
+  )
+
+  expect_equal(observed, expected, tolerance = 1e-12)
+}
+
+test_that("tile add and remove ratios use old counts and boundary factors", {
+  sigma_sq <- 1.7
+  sigma_mu <- 0.4
+  lambda_rate <- 3.2
+  omega <- 2
+  p <- 5
+
+  check_ac <- function(k_old, R_old, n_old, R_new, n_new) {
+    log_lik <- log_likelihood_ratio_for_test(
+      R_old, n_old, R_new, n_new, sigma_sq, sigma_mu
+    )
+    k_new <- k_old + 1
+    expected <- log_lik +
+      log(lambda_rate) -
+      2 * log(k_new) +
+      log(remove_centre_probability_for_test(k_new)) -
+      log(add_centre_probability_for_test(k_old)) +
+      0.5 * log(sigma_sq)
+
+    expect_acceptance_ratio(
+      R_old, n_old, R_new, n_new,
+      tess_rows = k_new, dim_count = 2,
+      sigma_sq = sigma_sq,
+      sigma_mu = sigma_mu,
+      modification = "AC",
+      omega = omega,
+      lambda_rate = lambda_rate,
+      p = p,
+      expected = expected
+    )
+  }
+
+  check_rc <- function(k_old, R_old, n_old, R_new, n_new) {
+    log_lik <- log_likelihood_ratio_for_test(
+      R_old, n_old, R_new, n_new, sigma_sq, sigma_mu
+    )
+    k_new <- k_old - 1
+    expected <- log_lik +
+      2 * log(k_old) -
+      log(lambda_rate) +
+      log(add_centre_probability_for_test(k_new)) -
+      log(remove_centre_probability_for_test(k_old)) -
+      0.5 * log(sigma_sq)
+
+    expect_acceptance_ratio(
+      R_old, n_old, R_new, n_new,
+      tess_rows = k_new, dim_count = 2,
+      sigma_sq = sigma_sq,
+      sigma_mu = sigma_mu,
+      modification = "RC",
+      omega = omega,
+      lambda_rate = lambda_rate,
+      p = p,
+      expected = expected
+    )
+  }
+
+  check_ac(
+    k_old = 3,
+    R_old = c(0.5, -0.2, 0.1),
+    n_old = c(2, 3, 4),
+    R_new = c(0.3, -0.1, 0.2, 0.4),
+    n_new = c(2, 2, 3, 2)
+  )
+  check_ac(
+    k_old = 1,
+    R_old = 0.5,
+    n_old = 9,
+    R_new = c(0.2, 0.3),
+    n_new = c(4, 5)
+  )
+  check_rc(
+    k_old = 4,
+    R_old = c(0.3, -0.1, 0.2, 0.4),
+    n_old = c(2, 2, 3, 2),
+    R_new = c(0.5, -0.2, 0.1),
+    n_new = c(2, 3, 4)
+  )
+  check_rc(
+    k_old = 2,
+    R_old = c(0.2, 0.3),
+    n_old = c(4, 5),
+    R_new = 0.5,
+    n_new = 9
+  )
+})
+
+test_that("dimension add and remove ratios use old counts and boundary factors", {
+  sigma_sq <- 1.2
+  sigma_mu <- 0.3
+  lambda_rate <- 2.5
+  R_old <- c(0.4, -0.2)
+  n_old <- c(4, 5)
+  R_new <- c(0.1, 0.1)
+  n_new <- c(3, 6)
+
+  check_ad <- function(d_old, p, omega) {
+    prob <- omega / p
+    d_new <- d_old + 1
+    log_lik <- log_likelihood_ratio_for_test(
+      R_old, n_old, R_new, n_new, sigma_sq, sigma_mu
+    )
+    expected <- log_lik +
+      2 * log(p - d_old) -
+      log(d_old) -
+      log(d_new) +
+      log(prob) -
+      log1p(-prob) +
+      log(remove_dimension_probability_for_test(d_new, p)) -
+      log(add_dimension_probability_for_test(d_old, p))
+
+    expect_acceptance_ratio(
+      R_old, n_old, R_new, n_new,
+      tess_rows = length(n_new), dim_count = d_new,
+      sigma_sq = sigma_sq,
+      sigma_mu = sigma_mu,
+      modification = "AD",
+      omega = omega,
+      lambda_rate = lambda_rate,
+      p = p,
+      expected = expected
+    )
+  }
+
+  check_rd <- function(d_old, p, omega) {
+    prob <- omega / p
+    d_new <- d_old - 1
+    log_lik <- log_likelihood_ratio_for_test(
+      R_old, n_old, R_new, n_new, sigma_sq, sigma_mu
+    )
+    expected <- log_lik +
+      log(d_old) +
+      log(d_new) -
+      2 * log(p - d_new) +
+      log1p(-prob) -
+      log(prob) +
+      log(add_dimension_probability_for_test(d_new, p)) -
+      log(remove_dimension_probability_for_test(d_old, p))
+
+    expect_acceptance_ratio(
+      R_old, n_old, R_new, n_new,
+      tess_rows = length(n_new), dim_count = d_new,
+      sigma_sq = sigma_sq,
+      sigma_mu = sigma_mu,
+      modification = "RD",
+      omega = omega,
+      lambda_rate = lambda_rate,
+      p = p,
+      expected = expected
+    )
+  }
+
+  check_ad(d_old = 3, p = 6, omega = 2)
+  check_ad(d_old = 1, p = 5, omega = 2)
+  check_ad(d_old = 4, p = 5, omega = 2)
+  check_rd(d_old = 4, p = 6, omega = 2)
+  check_rd(d_old = 2, p = 5, omega = 2)
+  check_rd(d_old = 5, p = 5, omega = 2)
+})
+
+test_that("dimension boundary factors do not double apply when p is two", {
+  sigma_sq <- 1.2
+  sigma_mu <- 0.3
+  lambda_rate <- 2.5
+  omega <- 1
+  p <- 2
+  prob <- omega / p
+  R_old <- c(0.4, -0.2)
+  n_old <- c(4, 5)
+  R_new <- c(0.1, 0.1)
+  n_new <- c(3, 6)
+  log_lik <- log_likelihood_ratio_for_test(
+    R_old, n_old, R_new, n_new, sigma_sq, sigma_mu
+  )
+
+  expected_ad <- log_lik +
+    2 * log(1) -
+    log(1) -
+    log(2) +
+    log(prob) -
+    log1p(-prob)
+
+  expect_acceptance_ratio(
+    R_old, n_old, R_new, n_new,
+    tess_rows = length(n_new), dim_count = 2,
+    sigma_sq = sigma_sq,
+    sigma_mu = sigma_mu,
+    modification = "AD",
+    omega = omega,
+    lambda_rate = lambda_rate,
+    p = p,
+    expected = expected_ad
+  )
+
+  expected_rd <- log_lik +
+    log(2) +
+    log(1) -
+    2 * log(1) +
+    log1p(-prob) -
+    log(prob)
+
+  expect_acceptance_ratio(
+    R_old, n_old, R_new, n_new,
+    tess_rows = length(n_new), dim_count = 1,
+    sigma_sq = sigma_sq,
+    sigma_mu = sigma_mu,
+    modification = "RD",
+    omega = omega,
+    lambda_rate = lambda_rate,
+    p = p,
+    expected = expected_rd
+  )
+})

--- a/tests/testthat/test-acceptanceProbability-ratios.R
+++ b/tests/testthat/test-acceptanceProbability-ratios.R
@@ -1,3 +1,13 @@
+if (!exists("acceptanceProbability")) {
+  acceptance_probability_file <- "R/0_AcceptanceProbability.R"
+  if (!file.exists(acceptance_probability_file)) {
+    acceptance_probability_file <- "../../R/0_AcceptanceProbability.R"
+  }
+  if (file.exists(acceptance_probability_file)) {
+    source(acceptance_probability_file)
+  }
+}
+
 log_likelihood_ratio_for_test <- function(R_old, n_old, R_new, n_new,
                                           sigma_sq, sigma_mu) {
   0.5 * (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Correct AC, RC, AD, and RD acceptance-ratio formulas to use old and new counts explicitly.
- Replace shifted boundary checks with proposal-probability helpers so reverse move factors are reciprocal.
- Keep R and C++ acceptance implementations aligned and add focused ratio tests.
- Refresh deterministic sampler expectations affected by the corrected MH ratios.

## Testing
- `Rscript -e "testthat::test_file('tests/testthat/test-acceptanceProbability-ratios.R')"`
- `R CMD INSTALL -l /workspace/.r-lib .`
- `R_LIBS="/workspace/.r-lib" Rscript testthat.R` from `tests/`
- `R_LIBS="/workspace/.r-lib" NOT_CRAN=true Rscript testthat.R` from `tests/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be67ada5-f7a0-41bc-8f6c-c158b772af07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be67ada5-f7a0-41bc-8f6c-c158b772af07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

