### PR TITLE
Set up Cursor Cloud dev environment for AddiVortes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`AddiVortes` is a standalone R package (R + C++20 via `src/addi_vortes_code.cpp`); there are no servers, databases, ports, or secrets. "Running the application" means loading the library and fitting/predicting a model. The startup update script already refreshes R dependencies (from `DESCRIPTION`) and reinstalls the package with `R CMD INSTALL .`, so the compiled `AddiVortes.so` is available on session start.
+
+Non-obvious caveats:
+
+- System tools (R >= 4.0.0, a C++20 compiler `g++`, and `pandoc`) are provided by the VM snapshot, not the update script. If R is missing, install via `sudo apt-get install -y r-base-dev` (and `pandoc` for vignette/README checks).
+- R packages install fast from the Posit binary mirror for Ubuntu noble: set `options(repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/noble/latest"))` plus a matching `HTTPUserAgent`, otherwise CRAN serves slow source builds.
+- Run the test suite with `Rscript -e 'testthat::test_local(".")'` (187 tests). Do NOT use `testthat::test_check("AddiVortes")` against the installed package: the package is installed without tests (no `--install-tests`), so it reports "No test files found".
+- Lint config lives in `.lintr.R` (not the usual `.lintr`) and defines a `linters` object. Run it with `Rscript -e 'library(lintr); source(".lintr.R"); print(lint_package(linters = linters))'`. There are pre-existing style lints, mostly in `vignettes/`.
+- Full CI-equivalent check: `R CMD build . --no-build-vignettes` then `R CMD check --no-manual --as-cran --ignore-vignettes <tarball>`. Expect only benign NOTEs (non-portable default R compile flag `-mno-omit-leaf-frame-pointer`, network-time, CRAN-incoming). CI errors only on warnings, not notes.
+- `data/Boston.rda` uses generic column names: predictors `x1`..`x13` and response `y` (there is no `medv` column).
+- Core API: `AddiVortes(y, x, ...)` returns an object of class `AddiVortes`; predict with `predict(fit, newx, showProgress = FALSE)`. Set `showProgress = FALSE` for non-interactive runs.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `AddiVortes` R package and documents durable, non-obvious guidance for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to test, lint, check, and run the package, plus gotchas (e.g. `test_local` vs `test_check`, the `.lintr.R` config, `Boston` column naming).
- No application code was modified; this is environment setup only.

## Environment

- System deps installed at snapshot level: R 4.3.3 (`r-base-dev`), `g++` 13.3 (C++20), `pandoc`.
- R deps installed from `DESCRIPTION` via the Posit noble binary mirror.
- Startup update script refreshes R deps and reinstalls the package (`R CMD INSTALL .`, recompiling the C++ source).

## Verification

- `Rscript -e 'testthat::test_local(".")'` → 187 tests pass.
- Lint runs via `.lintr.R` (pre-existing style lints only).
- `R CMD check --no-manual --as-cran --ignore-vignettes` → benign NOTEs only.
- Hello-world: fit `AddiVortes` on `Boston` and predict a held-out set (Test RMSE = 3.405).

[addivortes_env_demo.log](https://cursor.com/agents/bc-545f6d3b-747f-4ee1-8dfb-5b8668cc4ef3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faddivortes_env_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-545f6d3b-747f-4ee1-8dfb-5b8668cc4ef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-545f6d3b-747f-4ee1-8dfb-5b8668cc4ef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

