### PR TITLE
Fix out-of-sample prediction distance handling for spherical/permuted dimensions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AddiVortes
 Title: (Bayesian) Additive Voronoi Tessellations
-Version: 0.6.5
+Version: 0.6.6
 Authors@R: 
     c(person("Adam", "Stone", , "adam.stone2@durham.ac.uk",
              role = c("aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # AddiVortes News
 
-## AddiVortes 0.6.5
+## AddiVortes 0.6.6
 
 * Fixed out-of-sample prediction so that cell assignments match the in-sample
   fit. `cellIndices()` now always maps tessellation centre columns to their
@@ -12,6 +12,9 @@
   `covariateStructure_internal()` reorders covariates. Predictions on the
   training data now reproduce the in-sample fitted values, including for
   spherical and mixed-metric models.
+
+## AddiVortes 0.6.5
+
 * Metropolis-Hastings acceptance ratios have been further simplified in the C++
   MCMC implementation.
 * Removed legacy internal R functions for MCMC steps (acceptance probabilities,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@
 
 ## AddiVortes 0.6.5
 
+* Fixed out-of-sample prediction so that cell assignments match the in-sample
+  fit. `cellIndices()` now always maps tessellation centre columns to their
+  global covariate positions (previously the remapping was skipped when a
+  tessellation used every covariate, silently mismatching coordinates whenever
+  the active dimensions were in a permuted order). `predict()` now derives its
+  spherical column mask from the reordered/augmented metric so spherical
+  coordinates are left on their original radian scale even when
+  `covariateStructure_internal()` reorders covariates. Predictions on the
+  training data now reproduce the in-sample fitted values, including for
+  spherical and mixed-metric models.
 * Metropolis-Hastings acceptance ratios have been further simplified in the C++
   MCMC implementation.
 * Removed legacy internal R functions for MCMC steps (acceptance probabilities,

--- a/R/0_CellIndices.R
+++ b/R/0_CellIndices.R
@@ -25,11 +25,18 @@ cellIndices <- function(x, tess, dim, metric = "E", members) {
   if (n_tess == 1L) { # only 1 centre
     CellsForGivenTess <- rep.int(1L, n_x)
   } else { # multiple
-    if (ncol(tess) != ncol(x)) {
-      new_tess <- matrix(0, nrow = n_tess, ncol = ncol(x))
-      new_tess[, dim] <- tess
-      tess <- new_tess
-    }
+    # Always place the tessellation centre coordinates at their global column
+    # positions before computing distances. `tess` stores its columns in the
+    # order given by `dim` (the active dimensions), whereas the distance code
+    # (knnx_index_cpp) treats column i of `tess` as global covariate i. Guarding
+    # this remap on `ncol(tess) != ncol(x)` misses the case where every
+    # covariate is active (ncol(tess) == ncol(x)) but `dim` is a permutation of
+    # the columns, which silently mismatches coordinates (and, for spherical
+    # groups, the order-sensitive distance). Remapping unconditionally is a
+    # no-op when `dim` is already the identity order.
+    new_tess <- matrix(0, nrow = n_tess, ncol = ncol(x))
+    new_tess[, dim] <- tess
+    tess <- new_tess
     CellsForGivenTess <- knnx_index(
       tess,
       x, 1,

--- a/R/AddiVortesFit.R
+++ b/R/AddiVortesFit.R
@@ -378,7 +378,15 @@ predict.AddiVortes <- function(object, newdata,
     centres = object$xCentres,
     ranges = object$xRanges
   )
-  xNewScaled[, object$metric != 0] <- newdata[, object$metric != 0]
+  # Leave spherical columns on their original radian scale, exactly as the fit
+  # function does. The mask must be aligned to the (potentially reordered and
+  # augmented) column order of `newdata`, not the original user column order in
+  # `object$metric`: `covariateStructure_internal` may reorder covariates (e.g.
+  # move Euclidean covariates ahead of spherical ones). The per-column augmented
+  # metric is recovered from the reduced representation used for distances, which
+  # is already aligned to the reordered columns.
+  metricAug <- rep(object$metric_red, object$member_red)
+  xNewScaled[, metricAug != 0] <- newdata[, metricAug != 0]
   # Binary columns from categorical encoding are kept at their encoded values
   # (0 or catScaling) rather than being further scaled
   if (!is.null(object$catEncoding)) {

--- a/tests/testthat/test-spherical.R
+++ b/tests/testthat/test-spherical.R
@@ -55,6 +55,64 @@ test_that("predict preprocessing matches fit for spherical columns", {
   expect_equal(xNewScaled[, 2], lon)
 })
 
+test_that("cellIndices remaps permuted active dimensions to global columns", {
+  # Two active dimensions covering all covariates but given in reversed order.
+  # The centre matrix columns follow `dim` order (col 1 -> covariate 2,
+  # col 2 -> covariate 1). cellIndices must place them at the correct global
+  # columns before computing distances, matching a brute-force nearest centre.
+  x <- matrix(c(
+    0.0, 0.0,
+    1.0, 0.0,
+    0.0, 1.0,
+    1.0, 1.0
+  ), ncol = 2, byrow = TRUE)
+  tess <- matrix(c(
+    0.0, 1.0, # covariate 2 coordinates (dim[1] == 2)
+    0.0, 1.0  # covariate 1 coordinates (dim[2] == 1)
+  ), ncol = 2)
+  dim <- c(2L, 1L)
+
+  idx <- cellIndices(x, tess, dim, metric = 0L, members = 2L)
+
+  brute <- apply(x, 1, function(row) {
+    dists <- apply(tess, 1, function(cen) {
+      sum((row[dim] - cen)^2)
+    })
+    which.min(dists)
+  })
+
+  expect_equal(idx, brute)
+})
+
+test_that("in-sample and predicted values agree on the training data", {
+  skip_on_cran()
+
+  consistency <- function(x, metric) {
+    withr::local_seed(11)
+    n <- nrow(x)
+    y <- sin(2 * x[, 1]) + cos(x[, 2]) + rnorm(n, sd = 0.2)
+    fit <- AddiVortes(y, x,
+      m = 15, totalMCMCIter = 200, mcmcBurnIn = 60,
+      metric = metric, showProgress = FALSE
+    )
+    preds <- predict(fit, as.matrix(x), showProgress = FALSE, parallel = FALSE)
+    reRmse <- sqrt(mean((y - preds)^2))
+    abs(fit$inSampleRmse - reRmse)
+  }
+
+  n <- 120
+  lat <- runif(n, -pi / 4, pi / 4)
+  lon <- runif(n, -pi, pi)
+
+  # Euclidean control and spherical configurations, including column orders that
+  # force covariateStructure_internal to reorder covariates.
+  expect_lt(consistency(cbind(a = lat, b = lon), "E"), 1e-8)
+  expect_lt(consistency(cbind(lat = lat, lon = lon), "S"), 1e-8)
+  expect_lt(consistency(cbind(lon = lon, lat = lat), "S"), 1e-8)
+  expect_lt(consistency(cbind(e = lat, lat = lat, lon = lon), c("E", "S", "S")), 1e-8)
+  expect_lt(consistency(cbind(lat = lat, lon = lon, e = lon), c("S", "S", "E")), 1e-8)
+})
+
 test_that("spherical fit and predict preserve coordinate values", {
   skip_on_cran()
   withr::local_seed(42)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Answers the question: yes, there was a difference in how in-sample and out-of-sample predictions were computed, and it affected spherical (and any permuted-dimension) models. The in-sample path (C++ `knn1_internal`) was correct; the out-of-sample class method (`predict.AddiVortes`) diverged. Two distinct bugs are fixed so that `predict()` on the training data now reproduces the in-sample fitted values exactly.

## Root causes

Both prediction and fitting ultimately call the same C++ distance code (`calc_distance` / `spherical_distance`), so the divergence came from what was fed into them.

1. `cellIndices()` (`R/0_CellIndices.R`) only remapped tessellation centre columns to their global covariate positions when `ncol(tess) != ncol(x)`. When a tessellation used every covariate (`ncol(tess) == ncol(x)`) but the active dimensions `dim` were in a permuted order (e.g. `c(2, 1)`), the centre columns were left in `dim` order while `knnx_index_cpp` treats column `i` as global covariate `i`. This silently mismatched coordinates. The in-sample path always maps the `di`-th column to global column `dim[di]`, so it was correct. The remap is now unconditional (a no-op for identity order). This is metric-agnostic but especially harmful for spherical groups, whose distance is order-sensitive (the last coordinate is the azimuth).

2. `predict.AddiVortes()` (`R/AddiVortesFit.R`) built its "leave spherical columns on the original radian scale" mask from `object$metric`, which is in the original user column order. When `covariateStructure_internal()` reorders covariates (e.g. moving Euclidean covariates ahead of spherical ones), that mask is misaligned with the already-reordered `newdata`. The mask now uses the reordered/augmented per-column metric (`rep(object$metric_red, object$member_red)`), matching what the fit function does.

## Verification

For a battery of configurations, in-sample RMSE vs `predict()` on the training data now agree to machine precision (previously off by up to ~0.5):

| Configuration | diff before | diff after |
|---|---|---|
| Euclidean (control) | ~0.53 | 1.9e-16 |
| Spherical `lat,lon` | ~0.27 | 2.2e-16 |
| Spherical `lon,lat` (reorder) | ~0.36 | 8.3e-17 |
| Mixed `E,S,S` | small | 5.5e-17 |
| Mixed `S,S,E` (reorder) | 2.2e-02 | 1.1e-16 |
| Categorical + Euclidean | — | 1.1e-16 |
| Spherical + Categorical | — | 1.1e-16 |
| Two spheres (via `members`) | — | 0 |

- Added regression tests in `tests/testthat/test-spherical.R`: a direct `cellIndices()` permuted-dimension check against brute-force nearest centre, and an in-sample/out-of-sample consistency check across Euclidean, spherical and mixed-metric column orders.
- Full suite: 193 tests pass (was 187).

## Notes

- No changes to the in-sample C++ path or to public function signatures.
- A pre-existing warning from `AddiVortes.R`'s `mus` initialisation in the multi-sphere (`members`) case is unrelated to prediction and is left untouched to keep this change focused.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-545f6d3b-747f-4ee1-8dfb-5b8668cc4ef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-545f6d3b-747f-4ee1-8dfb-5b8668cc4ef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

