### PR TITLE
Update categorical vignette for one-hot vs Eskin distances (#87)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@
   compare the two approaches on a synthetic example. Andy Iskauskas added as a
   vignette author. The `cat.onehot` help text and fit-time covariate summary now
   mention Eskin distance as well.
+* Fixed a crash when fitting with `cat.onehot = FALSE` under the default
+  Euclidean `metric`: auto-detected categorical columns no longer keep a shared
+  Euclidean membership id, so Eskin distance and categorical centre proposals
+  receive the correct per-column level counts.
 * Fit and predict hot paths adopt several lessons from the Rust `addivortes`
   engine while preserving the sampled chain bit-for-bit on the fixed-seed
   Friedman and existing golden tests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## AddiVortes 0.7.1
 
+* Updated the categorical covariates vignette to document Eskin distance
+  (`cat.onehot = FALSE`), give guidance on choosing one-hot versus Eskin, and
+  compare the two approaches on a synthetic example. Andy Iskauskas added as a
+  vignette author. The `cat.onehot` help text and fit-time covariate summary now
+  mention Eskin distance as well.
 * Fit and predict hot paths adopt several lessons from the Rust `addivortes`
   engine while preserving the sampled chain bit-for-bit on the fixed-seed
   Friedman and existing golden tests:

--- a/R/0_CovariateStructure.R
+++ b/R/0_CovariateStructure.R
@@ -75,37 +75,55 @@ covariateStructure_internal <- function(data, structure, membership = NULL, one.
     membership <- new_member
     structure <- new_structure
   }
-  reduced_data <- data[,seq_along(membership),drop=FALSE]
+  reduced_data <- data[, seq_along(membership), drop = FALSE]
   for (i in seq_along(structure)) {
     struct <- structure[i]
     if (struct == "E") {
-      has_lev <- is.factor(reduced_data[,i]) || is.character(reduced_data[,i])
+      has_lev <- is.factor(reduced_data[, i]) || is.character(reduced_data[, i])
       if (has_lev) {
         struct <- structure[i] <- "C"
       }
     }
     if (struct == "C") {
-      has_lev <- is.factor(reduced_data[,i])
+      has_lev <- is.factor(reduced_data[, i])
       if (!has_lev) {
-        is_chr <- is.character(reduced_data[,i])
-        if (!is_chr) stop(paste("Covariate", names(reduced_data)[i],
-                                "specified as categorical but has neither",
-                                "levels nor is a character."))
-        reduced_data[,i] <- as.factor(reduced_data[,i])
+        is_chr <- is.character(reduced_data[, i])
+        if (!is_chr) {
+          stop(paste(
+            "Covariate", names(reduced_data)[i],
+            "specified as categorical but has neither",
+            "levels nor is a character."
+          ))
+        }
+        reduced_data[, i] <- as.factor(reduced_data[, i])
       }
-      if (!one.hot) reduced_data[,i] <- as.numeric(reduced_data[,i])
+      if (!one.hot) reduced_data[, i] <- as.numeric(reduced_data[, i])
     }
   }
+
+  ## Auto-detection may flip Euclidean columns to categorical without updating
+  ## membership. Rebuild membership so Euclidean (and spherical) groups are
+  ## preserved, while each categorical column gets its own group. Mixed E/C
+  ## columns must not share a membership id: the C++ distance reduction uses
+  ## the first column's metric for a whole membership block.
+  membership <- rebuildMembership_internal(structure, membership)
+
   if (any(structure == "S")) {
     members <- membership[structure == "S"]
     for (mem in unique(members)) {
-      sphere_data <- reduced_data[,which(membership == mem)]
-      has_lev <- sapply(seq_len(ncol(sphere_data)), function(idx) is.factor(sphere_data[,idx]))
-      if(any(has_lev)) stop("Covariate(s) specified as spherical have factors.")
+      sphere_data <- reduced_data[, which(membership == mem), drop = FALSE]
+      has_lev <- sapply(
+        seq_len(ncol(sphere_data)),
+        function(idx) is.factor(sphere_data[, idx])
+      )
+      if (any(has_lev)) stop("Covariate(s) specified as spherical have factors.")
       param_extent <- apply(apply(sphere_data, 2, range), 2, diff)
-      if (sum(param_extent > pi) > 1)
-        stop(paste("More than one spherical parameter in membership group",
-                                                 mem, "has range >pi."))
+      if (sum(param_extent > pi) > 1) {
+        stop(paste(
+          "More than one spherical parameter in membership group",
+          mem, "has range >pi."
+        ))
+      }
       if (sum(param_extent > pi) == 1) {
         mem_cols <- which(membership == mem)
         new_order <- c(which(param_extent <= pi), which(param_extent > pi))
@@ -115,17 +133,22 @@ covariateStructure_internal <- function(data, structure, membership = NULL, one.
     }
   }
   m_order <- order(membership)
-  structure <- structure[order(membership)]
-  membership <- membership[order(membership)]
+  reduced_data <- reduced_data[, m_order, drop = FALSE]
+  structure <- structure[m_order]
+  membership <- membership[m_order]
   ## If categoricals are going to be one-hot-encoded, then want to pre-emptively
   # expand the structure and membership
   if (one.hot && any(structure == "C")) {
-    n_onehot <- sum(sapply(seq_along(reduced_data)[structure == "C"], function(i) length(levels(reduced_data[,i]))-1))
+    n_onehot <- sum(sapply(
+      seq_along(reduced_data)[structure == "C"],
+      function(i) length(levels(reduced_data[, i])) - 1
+    ))
     membership <- membership[structure != "C"]
-    if (length(membership) == 0)
+    if (length(membership) == 0) {
       membership <- rep(1, n_onehot)
-    else
-      membership <- c(membership, rep(max(membership)+1, n_onehot))
+    } else {
+      membership <- c(membership, rep(max(membership) + 1, n_onehot))
+    }
     structure <- c(structure[structure != "C"], rep("C", n_onehot))
     structure[structure == "C"] <- "E"
   }
@@ -134,4 +157,40 @@ covariateStructure_internal <- function(data, structure, membership = NULL, one.
     structure = structure,
     membership = membership
   ))
+}
+
+#' Rebuild membership ids after structure auto-detection.
+#'
+#' @param structure Character vector of "E", "S", "C".
+#' @param membership Integer/numeric membership ids aligned with \code{structure}.
+#' @return Integer membership vector with Euclidean and spherical groups
+#'   preserved and each categorical column in its own group.
+#' @keywords internal
+#' @noRd
+rebuildMembership_internal <- function(structure, membership) {
+  n <- length(structure)
+  if (n == 0) {
+    return(integer(0))
+  }
+  membership <- as.integer(membership)
+  new_membership <- integer(n)
+  next_id <- 1L
+
+  assign_preserved_groups <- function(idx) {
+    if (length(idx) == 0) {
+      return()
+    }
+    for (g in unique(membership[idx])) {
+      new_membership[idx[membership[idx] == g]] <<- next_id
+      next_id <<- next_id + 1L
+    }
+  }
+
+  assign_preserved_groups(which(structure == "E"))
+  assign_preserved_groups(which(structure == "S"))
+  for (i in which(structure == "C")) {
+    new_membership[i] <- next_id
+    next_id <- next_id + 1L
+  }
+  new_membership
 }

--- a/R/AddiVortes.R
+++ b/R/AddiVortes.R
@@ -9,16 +9,18 @@
 #' the RMSE value for the test samples.
 #'
 #' The function can handle multiple types of covariates, including continuous, 
-#' spherical and categorical. Categorical covariates are automatically detected 
-#' and one-hot encoded, with the first level of each categorical variable used 
-#' as the reference category. The `catScaling` parameter allows control over 
-#' the weight of categorical differences in distance calculations. For spherical
-#' covariates, the function assumes that the final spherical dimension 
-#' corresponds to the polar angle, which has a range of 0 to 2*pi. The `metric` 
-#' parameter can be used to specify the type of each covariate (Euclidean, 
-#' Spherical, or Categorical), and the `members` parameter can indicate
-#' membership of covariates into different subspaces when using multiple spheres 
-#' in covariate space. 
+#' spherical and categorical. Categorical covariates are automatically detected.
+#' By default (`cat.onehot = TRUE`) they are one-hot encoded, with the first
+#' level of each categorical variable used as the reference category; the
+#' `catScaling` parameter then controls the weight of categorical differences in
+#' distance calculations. Setting `cat.onehot = FALSE` instead keeps each
+#' categorical covariate as a single integer-coded column and uses Eskin
+#' distance (Eskin et al., 2002). For spherical covariates, the function assumes
+#' that the final spherical dimension corresponds to the polar angle, which has
+#' a range of 0 to 2*pi. The `metric` parameter can be used to specify the type
+#' of each covariate (Euclidean, Spherical, or Categorical), and the `members`
+#' parameter can indicate membership of covariates into different subspaces when
+#' using multiple spheres in covariate space. 
 #'
 #' @param y A vector of the output values.
 #' @param x A matrix or data frame of the covariates. Character and factor columns
@@ -50,7 +52,14 @@
 #'   \code{<colname>_<level>} (e.g. a column \code{grp} with levels \code{"A"},
 #'   \code{"B"}, \code{"C"} produces columns \code{grp_B} and \code{grp_C}, with
 #'   \code{"A"} as the reference level).
-#' @param cat.onehot Should categorical covariates be one-hot encoded? Default `TRUE`.
+#' @param cat.onehot Should categorical covariates be one-hot encoded? Default
+#'   `TRUE`. When `TRUE`, each categorical covariate with *d* levels is expanded
+#'   to *d* − 1 binary indicators and distances are Euclidean (weighted by
+#'   \code{catScaling}). When `FALSE`, categories are kept as a single
+#'   integer-coded column and mismatches use Eskin distance (Eskin et al., 2002),
+#'   with squared cost \eqn{2 / d^2} when levels differ and 0 when they match;
+#'   \code{catScaling} is then ignored. See the categorical covariates vignette
+#'   for a comparison and guidance on which to use.
 #' @param showProgress Logical; if TRUE, a progress bar is shown during fitting.
 #'
 #' @return An AddiVortes object containing the posterior samples of the
@@ -448,28 +457,39 @@ formatCovariateSummary_internal <- function(x, metric, catEncoding = NULL,
   
   lines <- c(sprintf("Covariate summary: %s.", paste(parts, collapse = ", ")))
   
-  if (counts$categorical > 0 && coh) {
-    if (!is.null(catEncoding) && !is.null(catEncoding$encodedBinaryCols)) {
-      binary_cols <- length(catEncoding$encodedBinaryCols)
-      lines <- c(
-        lines,
-        sprintf(
-          paste0(
-            "Categorical covariates are expanded to %d one-hot encoded ",
-            "binary column%s, with the first level of each categorical ",
-            "variable used as the reference category."
-          ),
-          binary_cols,
-          if (binary_cols == 1L) "" else "s"
+  if (counts$categorical > 0) {
+    if (coh) {
+      if (!is.null(catEncoding) && !is.null(catEncoding$encodedBinaryCols)) {
+        binary_cols <- length(catEncoding$encodedBinaryCols)
+        lines <- c(
+          lines,
+          sprintf(
+            paste0(
+              "Categorical covariates are expanded to %d one-hot encoded ",
+              "binary column%s, with the first level of each categorical ",
+              "variable used as the reference category."
+            ),
+            binary_cols,
+            if (binary_cols == 1L) "" else "s"
+          )
         )
-      )
+      } else {
+        lines <- c(
+          lines,
+          paste0(
+            "Categorical covariates are expanded to one-hot encoded binary ",
+            "columns, with the first level of each categorical variable used ",
+            "as the reference category."
+          )
+        )
+      }
     } else {
       lines <- c(
         lines,
         paste0(
-          "Categorical covariates are expanded to one-hot encoded binary ",
-          "columns, with the first level of each categorical variable used ",
-          "as the reference category."
+          "Categorical covariates use Eskin distance (cat.onehot = FALSE): ",
+          "each stays as one integer-coded column, with mismatch cost 2/d^2 ",
+          "for a variable with d levels."
         )
       )
     }

--- a/man/AddiVortes.Rd
+++ b/man/AddiVortes.Rd
@@ -72,7 +72,14 @@ decrease below 1 to give them less weight. Binary indicator columns are named
 \code{"B"}, \code{"C"} produces columns \code{grp_B} and \code{grp_C}, with
 \code{"A"} as the reference level).}
 
-\item{cat.onehot}{Should categorical covariates be one-hot encoded? Default \code{TRUE}.}
+\item{cat.onehot}{Should categorical covariates be one-hot encoded? Default
+\code{TRUE}. When \code{TRUE}, each categorical covariate with \emph{d} levels is expanded
+to \emph{d} − 1 binary indicators and distances are Euclidean (weighted by
+\code{catScaling}). When \code{FALSE}, categories are kept as a single
+integer-coded column and mismatches use Eskin distance (Eskin et al., 2002),
+with squared cost \eqn{2 / d^2} when levels differ and 0 when they match;
+\code{catScaling} is then ignored. See the categorical covariates vignette
+for a comparison and guidance on which to use.}
 
 \item{showProgress}{Logical; if TRUE, a progress bar is shown during fitting.}
 }
@@ -90,16 +97,18 @@ Alongside fitting details and the posterior sample, the function returns
 the RMSE value for the test samples.
 
 The function can handle multiple types of covariates, including continuous,
-spherical and categorical. Categorical covariates are automatically detected
-and one-hot encoded, with the first level of each categorical variable used
-as the reference category. The \code{catScaling} parameter allows control over
-the weight of categorical differences in distance calculations. For spherical
-covariates, the function assumes that the final spherical dimension
-corresponds to the polar angle, which has a range of 0 to 2*pi. The \code{metric}
-parameter can be used to specify the type of each covariate (Euclidean,
-Spherical, or Categorical), and the \code{members} parameter can indicate
-membership of covariates into different subspaces when using multiple spheres
-in covariate space.
+spherical and categorical. Categorical covariates are automatically detected.
+By default (\code{cat.onehot = TRUE}) they are one-hot encoded, with the first
+level of each categorical variable used as the reference category; the
+\code{catScaling} parameter then controls the weight of categorical differences in
+distance calculations. Setting \code{cat.onehot = FALSE} instead keeps each
+categorical covariate as a single integer-coded column and uses Eskin
+distance (Eskin et al., 2002). For spherical covariates, the function assumes
+that the final spherical dimension corresponds to the polar angle, which has
+a range of 0 to 2*pi. The \code{metric} parameter can be used to specify the type
+of each covariate (Euclidean, Spherical, or Categorical), and the \code{members}
+parameter can indicate membership of covariates into different subspaces when
+using multiple spheres in covariate space.
 }
 \examples{
 \donttest{

--- a/src/addi_vortes_code.cpp
+++ b/src/addi_vortes_code.cpp
@@ -687,6 +687,11 @@ static ProposalResult propose_internal(
       }
     } else if (metric[global0] == 2) {
       const int ci = cat_index_of_col[global0];
+      if (ci < 0 || ci >= static_cast<int>(cats.size())) {
+        Rf_error("Categorical column %d has no Eskin level count; "
+                 "check membership grouping for categorical covariates.",
+                 global0 + 1);
+      }
       v = 1.0 + floor(unif_rand() * cats[ci]);
     }
     return v;

--- a/tests/testthat/test-AddiVortes-methods.R
+++ b/tests/testthat/test-AddiVortes-methods.R
@@ -130,6 +130,32 @@ test_that("covariate summary helper reports counts and categorical encoding", {
   )
 })
 
+test_that("covariate summary helper reports Eskin distance when cat.onehot is FALSE", {
+  x <- data.frame(
+    cont = c(1, 2, 3),
+    grp = factor(c("A", "B", "C"))
+  )
+
+  summary_lines <- AddiVortes:::formatCovariateSummary_internal(
+    x,
+    metric = c("E", "E"),
+    catEncoding = NULL,
+    coh = FALSE
+  )
+
+  expect_equal(
+    summary_lines,
+    c(
+      "Covariate summary: 1 continuous, 1 categorical.",
+      paste0(
+        "Categorical covariates use Eskin distance (cat.onehot = FALSE): ",
+        "each stays as one integer-coded column, with mismatch cost 2/d^2 ",
+        "for a variable with d levels."
+      )
+    )
+  )
+})
+
 test_that("AddiVortes startup output reports categorical encoding", {
   skip_on_cran()
   withr::local_seed(123)

--- a/tests/testthat/test-CategoricalCovariates.R
+++ b/tests/testthat/test-CategoricalCovariates.R
@@ -81,8 +81,13 @@ test_that("AddiVortes fits with both a d=2 and a d=3 categorical covariate", {
   # Total encoded columns: 2 + 1 + 2 = 5
   expect_equal(length(fit$xCentres), 5L)
 
-  # catColIndices: columns 2 and 4 in the original data frame
-  expect_equal(sort(fit$catEncoding$catColIndices), c(2L, 4L))
+  # Categorical columns are moved to the end for membership grouping, so
+  # catColIndices refer to the reordered frame (x1, x2, cat2, cat3).
+  expect_equal(sort(fit$catEncoding$catColIndices), c(3L, 4L))
+  expect_equal(
+    fit$catEncoding$origColNames,
+    c("x1", "x2", "cat2", "cat3")
+  )
 })
 
 test_that("predict works after fitting with categorical covariates", {
@@ -199,6 +204,56 @@ test_that("unseen categories at predict time map to the reference level (all zer
   expect_true(all(enc[1, binary_cols] == 0))
   # Row 2: "low" -> cat3_low = 1 (non-reference), cat3_mid = 0
   expect_equal(unname(enc[2, binary_cols]), c(1, 0))
+})
+
+test_that("covariateStructure assigns distinct membership for auto-detected categories", {
+  x <- data.frame(
+    age = rnorm(10),
+    income = runif(10),
+    region = factor(sample(c("East", "North", "South", "West"), 10, replace = TRUE)),
+    product = factor(sample(c("Basic", "Deluxe", "Premium"), 10, replace = TRUE))
+  )
+
+  san <- AddiVortes:::covariateStructure_internal(
+    x, structure = rep("E", 4), membership = NULL, one.hot = FALSE
+  )
+
+  expect_equal(san$structure, c("E", "E", "C", "C"))
+  # Euclidean columns share a group; each categorical has its own group
+  expect_equal(san$membership[1], san$membership[2])
+  expect_true(san$membership[3] != san$membership[1])
+  expect_true(san$membership[4] != san$membership[1])
+  expect_true(san$membership[3] != san$membership[4])
+  expect_equal(colnames(san$data), c("age", "income", "region", "product"))
+})
+
+test_that("AddiVortes fits with Eskin distance when cat.onehot is FALSE", {
+  skip_on_cran()
+  withr::local_seed(87)
+  n <- 40
+  x <- data.frame(
+    x1 = rnorm(n),
+    x2 = runif(n),
+    cat2 = factor(sample(c("A", "B"), n, replace = TRUE)),
+    cat3 = factor(sample(c("low", "mid", "high"), n, replace = TRUE),
+                  levels = c("high", "low", "mid"))
+  )
+  y <- rnorm(n)
+
+  fit <- AddiVortes(y, x,
+    m = 5, totalMCMCIter = 30, mcmcBurnIn = 10,
+    cat.onehot = FALSE, showProgress = FALSE
+  )
+
+  expect_true(is.finite(fit$inSampleRmse))
+  # No one-hot expansion: still 4 covariate columns
+  expect_equal(length(fit$xCentres), 4L)
+  expect_null(fit$catEncoding)
+
+  x_new <- x[1:5, ]
+  preds <- predict(fit, x_new, showProgress = FALSE)
+  expect_equal(length(preds), 5L)
+  expect_true(all(is.finite(preds)))
 })
 
 test_that("categorical-only covariates (no numeric columns) work", {
@@ -324,8 +379,9 @@ test_that("catEncoding stores correct origNCols and origColNames", {
   )
 
   expect_equal(fit$catEncoding$origNCols, 3L)
-  expect_equal(fit$catEncoding$origColNames, c("x1", "grp", "x2"))
-  # grp (d=3) -> 2 binary cols; total encoded = 1 + 2 + 1 = 4
+  # Categorical columns are moved to the end before encoding
+  expect_equal(fit$catEncoding$origColNames, c("x1", "x2", "grp"))
+  # grp (d=3) -> 2 binary cols; total encoded = 1 + 1 + 2 = 4
   expect_equal(length(fit$xCentres), 4L)
 })
 

--- a/vignettes/categorical.Rmd
+++ b/vignettes/categorical.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Using Categorical Covariates with AddiVortes"
-author: "John Paul Gosling and Adam Stone"
+author: "John Paul Gosling, Adam Stone, and Andy Iskauskas"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
@@ -16,7 +16,12 @@ knitr::opts_chunk$set(
 )
 ```
 
-This vignette explains how `AddiVortes` handles **categorical covariates** — variables that take a discrete set of named levels, such as region, product type, or treatment group. Because Voronoi tessellations require numerical distances between points, categorical variables must first be converted to numbers. `AddiVortes` does this automatically using **one-hot encoding**, and this vignette explains the encoding in detail.
+This vignette explains how `AddiVortes` handles **categorical covariates** — variables that take a discrete set of named levels, such as region, product type, or treatment group. Because Voronoi tessellations require numerical distances between points, categorical variables need a distance measure. `AddiVortes` offers two approaches, controlled by the `cat.onehot` argument:
+
+- **One-hot encoding** (`cat.onehot = TRUE`, the default): each categorical variable is expanded into binary indicator columns, and distances are Euclidean.
+- **Eskin distance** (`cat.onehot = FALSE`): categories are kept as a single integer-coded column, and mismatches use the Eskin et al. (2002) distance.
+
+Both approaches are applied automatically to any column in `x` that is of type `character` or `factor`. You do not need to pre-process your data.
 
 ### 1. What is One-Hot Encoding?
 
@@ -33,8 +38,6 @@ A categorical variable with *d* distinct levels cannot be treated as a number be
 
 The reference level ("East" here, as the alphabetically first) is represented by all zeros. Using *d − 1* rather than *d* columns avoids perfect collinearity while retaining full information about group membership.
 
-`AddiVortes` applies this encoding automatically to any column in `x` that is of type `character` or `factor`. You do not need to pre-process your data.
-
 ### 2. The `catScaling` Parameter
 
 After one-hot encoding, each indicator column takes values 0 or 1, while continuous covariates are normalised to the range [−0.5, 0.5]. If `catScaling = 1` (the default), the binary jump from 0 to 1 has a magnitude comparable to the full range of a normalised continuous covariate, giving categorical and continuous covariates roughly equal influence on the Voronoi tessellation distances.
@@ -46,7 +49,48 @@ You can adjust this with the `catScaling` argument:
 
 The column name for each binary indicator follows the pattern `<original_column>_<level>`. For example, a column `region` with levels `"East"`, `"North"`, `"South"`, `"West"` produces columns `region_North`, `region_South`, `region_West` (with `"East"` as reference).
 
-### 3. A Synthetic Example
+`catScaling` only applies when `cat.onehot = TRUE`. With Eskin distance it has no effect.
+
+### 3. Eskin Distance (`cat.onehot = FALSE`)
+
+Instead of expanding categories into binary columns, you can keep each categorical covariate as a single integer-coded column and measure mismatches with **Eskin distance** (Eskin et al., 2002). Set `cat.onehot = FALSE` when calling `AddiVortes()`:
+
+```{r eskin_usage, eval=FALSE}
+fit_eskin <- AddiVortes(
+  y = y_train,
+  x = x_train,
+  cat.onehot = FALSE,
+  showProgress = FALSE
+)
+```
+
+For a categorical variable with *d* levels, the squared Eskin contribution between two observations is:
+
+- **0** if the category levels match;
+- **2 / *d*²** if the category levels differ.
+
+So a mismatch on a binary covariate (*d* = 2) costs 2/4 = 0.5, while a mismatch on a four-level covariate costs 2/16 = 0.125. High-cardinality categories therefore contribute less to the overall distance when they disagree, which reflects the idea that a random mismatch is more likely when there are many levels.
+
+Because the covariate is not expanded, the model dimension stays the same as the number of original columns. That can be attractive when categories have many levels and one-hot encoding would create a large number of binary columns.
+
+### 4. Choosing Between One-Hot and Eskin
+
+| | One-hot (`cat.onehot = TRUE`) | Eskin (`cat.onehot = FALSE`) |
+|---|---|---|
+| Representation | *d* − 1 binary columns per categorical variable | One integer-coded column per categorical variable |
+| Distance | Euclidean on the binary indicators | Eskin: mismatch cost 2/*d*² |
+| Weighting | Controlled by `catScaling` | Built into the 2/*d*² formula; `catScaling` ignored |
+| High cardinality | Creates many columns | Keeps one column; mismatches are down-weighted |
+| Prediction metadata | Encoding stored in `fit$catEncoding` | Categories converted to numeric codes on the fly |
+| Unseen levels | Treated as the reference level | Prefer factors with a fixed level set so codes stay consistent |
+
+**Practical guidance:**
+
+- Use **one-hot** (the default) when you want an explicit, tunable weight for categorical differences, or when there are few levels per variable.
+- Use **Eskin** when categories have many levels, when you want to avoid expanding the covariate dimension, or when you prefer a mismatch cost that shrinks with cardinality.
+- For Eskin fits, supply categorical covariates as `factor`s with a consistent level set in training and prediction data so integer codes align.
+
+### 5. A Synthetic Example
 
 We create a dataset of 400 observations with two continuous covariates and two categorical covariates. The response variable depends on all four:
 
@@ -79,11 +123,11 @@ y <- 0.3 * x$age +
   rnorm(n, sd = 3)
 ```
 
-Note that `region` has 4 levels and `product` has 3 levels. When passed to `AddiVortes` as character columns, they will be encoded as 3 and 2 binary columns respectively — for a total of 5 extra columns alongside the 2 continuous covariates.
+Note that `region` has 4 levels and `product` has 3 levels. With one-hot encoding they become 3 and 2 binary columns respectively — for a total of 5 extra columns alongside the 2 continuous covariates. With Eskin distance they remain 2 categorical columns.
 
-### 4. Inspecting the Encoding
+### 6. Inspecting the Encoding
 
-We can call the internal encoding function directly to see exactly what the encoded matrix looks like before fitting the model.
+We can call the internal encoding function directly to see exactly what the one-hot encoded matrix looks like before fitting the model.
 
 ```{r inspect_encoding}
 # Show the first few rows of x before encoding
@@ -103,9 +147,9 @@ The columns produced are:
 
 All binary columns take values 0 or `catScaling` (here 1). When `catScaling = 1` all indicator columns and the continuous columns span a comparable range inside the model.
 
-### 5. Fitting the Model
+### 7. Fitting the Model (One-Hot)
 
-Fitting the model is identical to the standard workflow — simply pass the data frame with character or factor columns directly. `AddiVortes` handles the encoding internally.
+Fitting the model is identical to the standard workflow — simply pass the data frame with character or factor columns directly. `AddiVortes` handles the encoding internally (`cat.onehot = TRUE` is the default).
 
 ```{r fit_model, results='hide'}
 # Split into training and test sets
@@ -124,6 +168,7 @@ fit <- AddiVortes(
   totalMCMCIter = 500,
   mcmcBurnIn = 100,
   catScaling = 1, # default: binary columns span [0, 1]
+  cat.onehot = TRUE, # default: one-hot encoding
   showProgress = FALSE
 )
 ```
@@ -146,7 +191,7 @@ for (j in fit$catEncoding$catColIndices) {
 
 The encoding metadata is stored in `fit$catEncoding` and is automatically used when making predictions, so new data passed to `predict()` is encoded with exactly the same reference levels.
 
-### 6. Making Predictions
+### 8. Making Predictions
 
 Predictions on new data work in the usual way. If the new data contains the same categorical levels as the training data, the encoding is applied consistently.
 
@@ -178,9 +223,9 @@ legend("topleft",
 )
 ```
 
-### 7. Handling Unseen Category Levels
+### 9. Handling Unseen Category Levels
 
-At prediction time, if a new observation contains a category level that was not seen during training, `AddiVortes` treats it as the **reference level** (all binary indicators set to zero). This is a sensible default: the model cannot infer anything about a previously unseen level and falls back to the baseline.
+At prediction time under one-hot encoding, if a new observation contains a category level that was not seen during training, `AddiVortes` treats it as the **reference level** (all binary indicators set to zero). This is a sensible default: the model cannot infer anything about a previously unseen level and falls back to the baseline.
 
 ```{r unseen_level}
 # Create a test point with an unseen product level "Luxury"
@@ -204,9 +249,9 @@ cat(
 )
 ```
 
-### 8. Effect of `catScaling`
+### 10. Effect of `catScaling`
 
-The `catScaling` parameter controls how much influence categorical differences have in the distance calculations. Here we fit two models — one with `catScaling = 1` (equal weight) and one with `catScaling = 2` (double weight for categorical differences) — and compare their test RMSEs.
+The `catScaling` parameter controls how much influence categorical differences have in the distance calculations under one-hot encoding. Here we fit two models — one with `catScaling = 1` (equal weight) and one with `catScaling = 2` (double weight for categorical differences) — and compare their test RMSEs.
 
 ```{r catscaling_comparison, results='hide'}
 fit_cs2 <- AddiVortes(
@@ -216,6 +261,7 @@ fit_cs2 <- AddiVortes(
   totalMCMCIter = 500,
   mcmcBurnIn = 100,
   catScaling = 2, # give categorical differences twice as much weight
+  cat.onehot = TRUE,
   showProgress = FALSE
 )
 ```
@@ -231,12 +277,74 @@ cat("Test RMSE (catScaling = 2):", round(sqrt(mean((y_test - preds_cs2)^2)), 3),
 
 In this example, the true response has substantial category effects (up to ±20 units for product type) relative to the continuous effects, so increasing `catScaling` may help the model focus more on categorical group membership.
 
-### 9. Summary of Key Points
+### 11. Comparing One-Hot and Eskin Distances
 
-- Pass `character` or `factor` columns directly in the covariate data frame; `AddiVortes` encodes them automatically.
-- **One-hot encoding**: a categorical variable with *d* levels is converted to *d − 1* binary (0/1) indicator columns.
-- The **reference level** is the alphabetically first level; all its indicators are zero.
+We now fit the same training data with Eskin distance and compare test RMSE with the default one-hot model. For a fair comparison we keep `m`, MCMC length, and burn-in identical.
+
+```{r fit_eskin, results='hide'}
+# Use factors with fixed levels so integer codes stay aligned at prediction
+x_train_f <- x_train
+x_test_f <- x_test
+x_train_f$region <- factor(x_train$region, levels = c("East", "North", "South", "West"))
+x_train_f$product <- factor(x_train$product, levels = c("Basic", "Deluxe", "Premium"))
+x_test_f$region <- factor(x_test$region, levels = levels(x_train_f$region))
+x_test_f$product <- factor(x_test$product, levels = levels(x_train_f$product))
+
+fit_eskin <- AddiVortes(
+  y = y_train,
+  x = x_train_f,
+  m = 50,
+  totalMCMCIter = 500,
+  mcmcBurnIn = 100,
+  cat.onehot = FALSE, # Eskin distance on integer-coded categories
+  showProgress = FALSE
+)
+```
+
+```{r eskin_predictions, results='hide'}
+preds_eskin <- predict(fit_eskin, x_test_f, showProgress = FALSE)
+```
+
+```{r eskin_comparison}
+rmse_eskin <- sqrt(mean((y_test - preds_eskin)^2))
+cat("Test RMSE (one-hot, catScaling = 1):", round(rmse_test, 3), "\n")
+cat("Test RMSE (Eskin):                   ", round(rmse_eskin, 3), "\n")
+cat("In-sample RMSE (one-hot):", round(fit$inSampleRmse, 3), "\n")
+cat("In-sample RMSE (Eskin):  ", round(fit_eskin$inSampleRmse, 3), "\n")
+```
+
+```{r plot_eskin_comparison, fig.width=7, fig.height=5, fig.align='center'}
+plot(y_test, preds,
+  col = adjustcolor("steelblue", alpha.f = 0.7), pch = 19, cex = 0.8,
+  xlab = "Observed values",
+  ylab = "Predicted values",
+  main = "One-hot vs Eskin: predicted vs observed"
+)
+points(y_test, preds_eskin,
+  col = adjustcolor("darkorange", alpha.f = 0.7), pch = 17, cex = 0.8
+)
+abline(0, 1, lwd = 2, lty = 2, col = "grey40")
+legend("topleft",
+  legend = c("One-hot", "Eskin"),
+  col = c("steelblue", "darkorange"),
+  pch = c(19, 17), bty = "n"
+)
+```
+
+Neither method is universally better: one-hot gives a flexible Euclidean embedding whose weight you can tune with `catScaling`, while Eskin keeps the original dimension and scales mismatch cost by cardinality. On a given problem, comparing the two on a held-out set (as above) is a practical way to choose.
+
+### 12. Summary of Key Points
+
+- Pass `character` or `factor` columns directly in the covariate data frame; `AddiVortes` detects them automatically.
+- **One-hot encoding** (`cat.onehot = TRUE`, default): a categorical variable with *d* levels is converted to *d − 1* binary (0/1) indicator columns.
+- **Eskin distance** (`cat.onehot = FALSE`): categories stay as one integer-coded column; a mismatch costs 2/*d*² (Eskin et al., 2002).
+- The **reference level** under one-hot is the alphabetically first level; all its indicators are zero.
 - Indicator columns are named `<original_column>_<level>` (e.g. `product_Premium`).
-- **`catScaling`** (default 1) controls the weight given to categorical differences relative to continuous differences. Increase it to give categories more influence; decrease it to give them less.
-- The encoding metadata is stored in `fit$catEncoding` and applied automatically to new data in `predict()`.
-- Unseen category levels at prediction time are treated as the reference level.
+- **`catScaling`** (default 1) controls the weight given to categorical differences under one-hot encoding. It is ignored when `cat.onehot = FALSE`.
+- One-hot encoding metadata is stored in `fit$catEncoding` and applied automatically to new data in `predict()`.
+- Unseen category levels at prediction time under one-hot encoding are treated as the reference level.
+- For Eskin fits, prefer `factor` covariates with a fixed level set shared by training and prediction data.
+
+### References
+
+Eskin, E., Arnold, A., Prerau, M., Portnoy, L. and Stolfo, S. (2002). A geometric framework for unsupervised anomaly detection. In *Applications of Data Mining in Computer Security*, pp. 77–101. Springer.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #87.

## Summary
- Expands the categorical covariates vignette with Eskin distance (`cat.onehot = FALSE`), a choice table for one-hot vs Eskin, and a side-by-side synthetic comparison.
- Adds Andy Iskauskas as a vignette author.
- Documents Eskin in the `cat.onehot` help text and in the fit-time covariate summary when one-hot encoding is off.

## Bug fix (needed for the vignette comparison)
- Fitting with `cat.onehot = FALSE` under the default Euclidean `metric` no longer crashes. Auto-detected categorical columns now get distinct membership ids and are ordered into contiguous membership blocks, so Eskin level counts and categorical centre proposals work correctly.

## Testing
- Full `testthat` suite passes with `NOT_CRAN=true`.
- `vignettes/categorical.Rmd` renders successfully, including the one-hot vs Eskin comparison.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4271b9ac-dc52-4598-8797-ad541d01e786?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4271b9ac-dc52-4598-8797-ad541d01e786&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

