### PR TITLE
Add binary and multinomial probit classification (v1.0.0)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,6 +27,15 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      # Distro/toolchain flags from the runner's R Makeconf, not from this
+      # package (there is no src/Makevars). Treat them as known so
+      # "checking compilation flags used" does not NOTE on GHA.
+      _R_CHECK_COMPILATION_FLAGS_KNOWN_: >-
+        -Werror=format-security -Wformat -Wdate-time
+        -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS
+        -march=x86-64-v3 -mpclmul -mno-omit-leaf-frame-pointer
+        -fno-omit-frame-pointer -fstack-protector-strong
+        -fstack-clash-protection -fcf-protection
 
     steps:
       - uses: actions/checkout@v4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AddiVortes
 Title: (Bayesian) Additive Voronoi Tessellations
-Version: 0.7.1
+Version: 1.0.0
 Authors@R: 
     c(person("Adam", "Stone", , "adam.stone2@durham.ac.uk",
              role = c("aut"),
@@ -12,14 +12,15 @@ Authors@R:
              role = c("aut"),
              comment = c(ORCID = "0000-0003-2825-3651")))
 Description: Implements the Bayesian Additive Voronoi Tessellation 
-    model for non-parametric regression and machine learning as introduced
-    in Stone and Gosling (2025) <doi:10.1080/10618600.2024.2414104>.
+    model for non-parametric regression, classification and machine learning as
+    introduced in Stone and Gosling (2025) <doi:10.1080/10618600.2024.2414104>.
     This package provides a flexible alternative to BART (Bayesian Additive 
     Regression Trees) using Voronoi tessellations instead of trees. Users can 
-    fit Bayesian regression models (estimating the associated posterior 
-    distributions and make predictions). It is particularly useful for spatial
-    data analysis, machine learning regression, complex function approximation 
-    and Bayesian modeling where the underlying structure is unknown.
+    fit Bayesian regression and probit classification models, estimate the
+    associated posterior distributions and make predictions. It is particularly
+    useful for spatial data analysis, machine learning, complex function
+    approximation and Bayesian modelling where the underlying structure is
+    unknown.
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
@@ -37,4 +38,4 @@ URL: https://johnpaulgosling.github.io/AddiVortes/
 VignetteBuilder: knitr
 BugReports: https://github.com/johnpaulgosling/AddiVortes/issues
 LazyData: true
-Config/roxygen2/version: 8.1.0
+Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,4 +38,4 @@ URL: https://johnpaulgosling.github.io/AddiVortes/
 VignetteBuilder: knitr
 BugReports: https://github.com/johnpaulgosling/AddiVortes/issues
 LazyData: true
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -9,30 +9,34 @@ export(AddiVortes)
 export(cellIndices)
 export(new_AddiVortes)
 export(traceplots)
-importFrom(graphics,abline)
-importFrom(graphics,layout)
-importFrom(graphics,legend)
-importFrom(graphics,lines)
-importFrom(graphics,par)
-importFrom(graphics,plot)
-importFrom(graphics,points)
-importFrom(graphics,segments)
-importFrom(graphics,text)
-importFrom(graphics,title)
-importFrom(stats,dbinom)
-importFrom(stats,dpois)
-importFrom(stats,fitted)
-importFrom(stats,lm)
-importFrom(stats,lowess)
-importFrom(stats,optim)
-importFrom(stats,pnorm)
-importFrom(stats,predict)
-importFrom(stats,qnorm)
-importFrom(stats,quantile)
-importFrom(stats,residuals)
-importFrom(stats,rnorm)
-importFrom(stats,runif)
-importFrom(stats,sd)
-importFrom(stats,uniroot)
-importFrom(stats,var)
+importFrom(graphics,
+  abline,
+  layout,
+  legend,
+  lines,
+  par,
+  plot,
+  points,
+  segments,
+  text,
+  title
+)
+importFrom(stats,
+  dbinom,
+  dpois,
+  fitted,
+  lm,
+  lowess,
+  optim,
+  pnorm,
+  predict,
+  qnorm,
+  quantile,
+  residuals,
+  rnorm,
+  runif,
+  sd,
+  uniroot,
+  var
+)
 useDynLib(AddiVortes, .registration = TRUE)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -9,33 +9,30 @@ export(AddiVortes)
 export(cellIndices)
 export(new_AddiVortes)
 export(traceplots)
-importFrom(graphics,
-  abline,
-  layout,
-  legend,
-  lines,
-  par,
-  plot,
-  points,
-  segments,
-  text,
-  title
-)
-importFrom(stats,
-  dbinom,
-  dpois,
-  fitted,
-  lm,
-  lowess,
-  optim,
-  predict,
-  qnorm,
-  quantile,
-  residuals,
-  rnorm,
-  runif,
-  sd,
-  uniroot,
-  var
-)
+importFrom(graphics,abline)
+importFrom(graphics,layout)
+importFrom(graphics,legend)
+importFrom(graphics,lines)
+importFrom(graphics,par)
+importFrom(graphics,plot)
+importFrom(graphics,points)
+importFrom(graphics,segments)
+importFrom(graphics,text)
+importFrom(graphics,title)
+importFrom(stats,dbinom)
+importFrom(stats,dpois)
+importFrom(stats,fitted)
+importFrom(stats,lm)
+importFrom(stats,lowess)
+importFrom(stats,optim)
+importFrom(stats,pnorm)
+importFrom(stats,predict)
+importFrom(stats,qnorm)
+importFrom(stats,quantile)
+importFrom(stats,residuals)
+importFrom(stats,rnorm)
+importFrom(stats,runif)
+importFrom(stats,sd)
+importFrom(stats,uniroot)
+importFrom(stats,var)
 useDynLib(AddiVortes, .registration = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # AddiVortes News
 
+## AddiVortes 1.0.0
+
+* Added binary and multi-category classification. `AddiVortes()` chooses
+  regression or classification from the response: factor, character and logical
+  vectors are classification (two levels: binary probit; three or more:
+  multinomial probit), numeric 0/1 responses are binary classification, and any
+  other numeric response remains Gaussian regression.
+* Binary classification follows the Albert-Chib latent-variable probit
+  extension of AddiVortes. Multi-category classification uses \(K-1\)
+  independent latent ensembles, with the first class as the reference level.
+  The residual variance is fixed at 1 on the latent scale, and cell means use
+  \(\sigma_\mu = 3/(k\sqrt{m})\).
+* `predict()` gains `type = "class"` and `type = "link"`. For classification,
+  `type = "response"` returns class probabilities and `type = "quantile"`
+  returns credible intervals on those probabilities. Prediction intervals are
+  not used for classification models.
+* Added a classification vignette covering automatic task detection, binary
+  probabilities and intervals, and multi-category probability matrices.
+
 ## AddiVortes 0.7.1
 
 * Updated the categorical covariates vignette to document Eskin distance

--- a/R/0_ResponseType.R
+++ b/R/0_ResponseType.R
@@ -1,0 +1,181 @@
+#' @title Infer the modelling task from a response vector
+#'
+#' @description
+#' Detects whether `y` should be treated as a regression, binary classification
+#' or multinomial classification response.
+#'
+#' Factor, character and logical vectors are treated as classification (two
+#' levels: binary; three or more: multinomial). Numeric `y` with exactly two
+#' unique values in `{0, 1}` is binary classification. Any other numeric `y`
+#' is regression.
+#'
+#' @param y A response vector.
+#'
+#' @return A list with `task`, `classLevels`, `yClass` (0-based integer codes,
+#'   or `NULL` for regression) and `nLatents`.
+#'
+#' @keywords internal
+#' @noRd
+infer_response_type_internal <- function(y) {
+  if (is.null(y)) {
+    stop("'y' must be provided.", call. = FALSE)
+  }
+  if (length(y) < 1L) {
+    stop("'y' must have length greater than 0.", call. = FALSE)
+  }
+  if (anyNA(y)) {
+    stop("'y' must not contain missing values.", call. = FALSE)
+  }
+
+  if (is.factor(y) || is.character(y) || is.logical(y)) {
+    if (is.character(y)) {
+      y_fac <- factor(y)
+    } else if (is.logical(y)) {
+      y_fac <- factor(y, levels = c(FALSE, TRUE))
+    } else {
+      y_fac <- droplevels(y)
+    }
+    levels_y <- levels(y_fac)
+    if (length(levels_y) < 2L) {
+      stop("Classification responses must have at least two classes.",
+           call. = FALSE)
+    }
+    codes <- as.integer(y_fac) - 1L
+    task <- if (length(levels_y) == 2L) "binary" else "multinomial"
+    return(list(
+      task = task,
+      classLevels = levels_y,
+      yClass = codes,
+      nLatents = length(levels_y) - 1L
+    ))
+  }
+
+  if (is.numeric(y)) {
+    unique_y <- unique(y)
+    if (length(unique_y) == 2L && all(unique_y %in% c(0, 1))) {
+      return(list(
+        task = "binary",
+        classLevels = c("0", "1"),
+        yClass = as.integer(y == 1),
+        nLatents = 1L
+      ))
+    }
+    return(list(
+      task = "regression",
+      classLevels = NULL,
+      yClass = NULL,
+      nLatents = 1L
+    ))
+  }
+
+  stop("'y' must be numeric, factor, character, or logical.", call. = FALSE)
+}
+
+#' @title Independent-probit class probabilities from latent means
+#'
+#' @description
+#' For a list of `nLatents` matrices of latent means `G_d` (each `n` by
+#' `nDraws`), estimate class probabilities under independent N(G, I) latents.
+#' The reference class (index 1) is chosen when every latent is negative;
+#' otherwise the class is `which.max(z) + 1`.
+#'
+#' @param G_list A list of numeric matrices, one per latent dimension.
+#' @param nMC Number of Monte Carlo draws of `z ~ N(G, I)` per posterior draw.
+#' @param perDraw If `TRUE`, also return an `n x K x nDraws` array of
+#'   per-draw probabilities.
+#'
+#' @return A list with `mean` (`n x K` matrix) and optionally `draw`.
+#'
+#' @keywords internal
+#' @noRd
+multinomialProbabilities_internal <- function(G_list, nMC = 32L,
+                                              perDraw = FALSE) {
+  n <- nrow(G_list[[1]])
+  n_draws <- ncol(G_list[[1]])
+  n_latents <- length(G_list)
+  k_classes <- n_latents + 1L
+  counts <- matrix(0, n, k_classes)
+  draw_probs <- if (perDraw) {
+    array(0, dim = c(n, k_classes, n_draws))
+  } else {
+    NULL
+  }
+
+  row_idx <- seq_len(n)
+  for (s in seq_len(n_draws)) {
+    g <- matrix(0, n, n_latents)
+    for (d in seq_len(n_latents)) {
+      g[, d] <- G_list[[d]][, s]
+    }
+    class_counts <- matrix(0, n, k_classes)
+    for (ignored in seq_len(nMC)) {
+      z <- g + matrix(stats::rnorm(n * n_latents), n, n_latents)
+      max_z <- z[, 1]
+      if (n_latents > 1L) {
+        for (d in 2:n_latents) {
+          max_z <- pmax(max_z, z[, d])
+        }
+      }
+      winner <- max.col(z, ties.method = "first")
+      cls <- ifelse(max_z < 0, 1L, winner + 1L)
+      class_counts[cbind(row_idx, cls)] <- class_counts[cbind(row_idx, cls)] + 1
+    }
+    if (perDraw) {
+      draw_probs[, , s] <- class_counts / nMC
+    }
+    counts <- counts + class_counts
+  }
+
+  list(mean = counts / (n_draws * nMC), draw = draw_probs)
+}
+
+#' @title Posterior latent-link matrices for each ensemble
+#'
+#' @description
+#' Evaluates `G_d(x)` for each latent ensemble by calling the compiled
+#' predictor on the corresponding subset of tessellations.
+#'
+#' @keywords internal
+#' @noRd
+latentLinkMatrices_internal <- function(object, x_scaled, showProgress = FALSE) {
+  n_latents <- object$nLatents
+  if (is.null(n_latents) || n_latents < 1L) {
+    n_latents <- 1L
+  }
+  m_per <- object$mPerLatent
+  if (is.null(m_per) || is.na(m_per)) {
+    n_tess <- if (length(object$posteriorTess) > 0) {
+      length(object$posteriorTess[[1]])
+    } else {
+      0L
+    }
+    m_per <- as.integer(n_tess / n_latents)
+  }
+
+  G_list <- vector("list", n_latents)
+  for (d in seq_len(n_latents)) {
+    idx <- ((d - 1L) * m_per + 1L):(d * m_per)
+    tess_d <- lapply(object$posteriorTess, function(draw) draw[idx])
+    dim_d <- lapply(object$posteriorDim, function(draw) draw[idx])
+    pred_d <- lapply(object$posteriorPred, function(draw) draw[idx])
+    G_list[[d]] <- .Call(
+      "addi_vortes_predict_cpp",
+      x_scaled,
+      tess_d,
+      dim_d,
+      pred_d,
+      as.integer(object$metric_red),
+      as.integer(object$member_red),
+      as.logical(showProgress && d == n_latents)
+    )
+  }
+  G_list
+}
+
+#' @title Whether an AddiVortes object is a classification fit
+#'
+#' @keywords internal
+#' @noRd
+isClassification_internal <- function(object) {
+  !is.null(object$task) && object$task %in% c("binary", "multinomial")
+}

--- a/R/AddiVortes-package.R
+++ b/R/AddiVortes-package.R
@@ -2,27 +2,40 @@
 #'
 #' @description
 #' AddiVortes implements Bayesian Additive Voronoi Tessellation models for
-#' machine learning regression and non-parametric statistical modeling. This
-#' package provides a flexible alternative to BART (Bayesian Additive Regression
-#' Trees), using Voronoi tessellations instead of trees for spatial partitioning.
-#' The method is particularly effective for spatial data analysis, complex
-#' function approximation, and Bayesian regression modeling.
+#' machine learning regression, classification and non-parametric statistical
+#' modelling. This package provides a flexible alternative to BART (Bayesian
+#' Additive Regression Trees), using Voronoi tessellations instead of trees for
+#' spatial partitioning. The method is particularly effective for spatial data
+#' analysis, complex function approximation, and Bayesian regression and
+#' classification.
 #'
 #' @details
 #' Key features include:
 #' \itemize{
-#'   \item Machine learning regression with Bayesian inference
+#'   \item Machine learning regression and classification with Bayesian inference
+#'   \item Binary and multinomial probit models with latent-variable data
+#'     augmentation
 #'   \item Alternative to BART using Voronoi tessellations
-#'   \item Spatial data analysis and modeling
+#'   \item Spatial data analysis and modelling
 #'   \item Non-parametric regression capabilities
 #'   \item Complex function approximation
 #'   \item Uncertainty quantification through posterior inference
 #' }
 #'
-#' @keywords package machine-learning bayesian regression BART spatial tessellation
+#' @keywords package machine-learning bayesian regression classification BART spatial tessellation
 #' @references
 #' Stone, A. and Gosling, J.P. (2025). AddiVortes: (Bayesian) additive Voronoi
 #' tessellations. Journal of Computational and Graphical Statistics.
+#'
+#' Stone, A.J., Ogundimu, E. and Gosling, J.P. (2026). Binary AddiVortes:
+#' (Bayesian) Additive Voronoi Tessellations for Binary Classification with an
+#' application to Predicting Home Mortgage Application Outcomes.
+#'
+#' Albert, J.H. and Chib, S. (1993). Bayesian analysis of binary and
+#' polychotomous response data. Journal of the American Statistical Association.
+#'
+#' Kindo, B.P., Wang, H. and Peña, E.A. (2016). Multinomial probit Bayesian
+#' additive regression trees. Stat.
 #'
 #' @seealso
 #' \url{https://johnpaulgosling.github.io/AddiVortes/}

--- a/R/AddiVortes.R
+++ b/R/AddiVortes.R
@@ -33,8 +33,8 @@
 #'   are treated as categorical variables and automatically converted to d-1 binary
 #'   indicator variables via one-hot encoding (with the first level as reference).
 #' @param m The number of tessellations. For multinomial classification this is
-#'   the number of tessellations **per latent dimension** (there are \(K-1\)
-#'   latents for \(K\) classes).
+#'   the number of tessellations **per latent dimension** (there are
+#'   \eqn{K-1}{K-1} latents for \eqn{K}{K} classes).
 #' @param totalMCMCIter The number of iterations.
 #' @param mcmcBurnIn The number of burn in iterations.
 #' @param nu The degrees of freedom for the inverse-gamma prior on the residual
@@ -43,8 +43,10 @@
 #' @param q The quantile used to set the inverse-gamma prior on the residual
 #'   variance. Ignored for classification.
 #' @param k Prior scale for tessellation output values. For regression,
-#'   \(\sigma_\mu = 0.5/(k\sqrt{m})\) on the scaled response. For classification,
-#'   \(\sigma_\mu = 3/(k\sqrt{m})\) on the latent probit scale.
+#'   \eqn{\sigma_\mu = 0.5/(k\sqrt{m})}{sigma_mu = 0.5/(k sqrt(m))} on the scaled
+#'   response. For classification,
+#'   \eqn{\sigma_\mu = 3/(k\sqrt{m})}{sigma_mu = 3/(k sqrt(m))} on the latent
+#'   probit scale.
 #' @param sd The standard deviation used in centre proposals.
 #' @param Omega Omega/(number of covariates) is the prior probability of
 #'   adding a dimension.

--- a/R/AddiVortes.R
+++ b/R/AddiVortes.R
@@ -1,14 +1,14 @@
-#' @title Fit an AddiVortes regression model 
+#' @title Fit an AddiVortes regression or classification model
 #'
 #' @description
-#' The AddiVortes model is a Bayesian nonparametric regression model that
-#' uses a tessellation to model the relationship between the covariates and
-#' the output values. The model uses a backfitting algorithm to sample from
-#' the posterior distribution of the output values for each tessellation.
-#' Alongside fitting details and the posterior sample, the function returns 
-#' the RMSE value for the test samples.
+#' The AddiVortes model is a Bayesian nonparametric model that uses additive
+#' Voronoi tessellations to relate covariates to a response. For a numeric
+#' response the model is Gaussian regression. For a classification response
+#' it uses a probit link with Albert-Chib latent variables (binary) or
+#' independent multinomial probit latents (three or more classes). The task is
+#' chosen automatically from `y`.
 #'
-#' The function can handle multiple types of covariates, including continuous, 
+#' The function can handle multiple types of covariates, including continuous,
 #' spherical and categorical. Categorical covariates are automatically detected.
 #' By default (`cat.onehot = TRUE`) they are one-hot encoded, with the first
 #' level of each categorical variable used as the reference category; the
@@ -20,23 +20,38 @@
 #' a range of 0 to 2*pi. The `metric` parameter can be used to specify the type
 #' of each covariate (Euclidean, Spherical, or Categorical), and the `members`
 #' parameter can indicate membership of covariates into different subspaces when
-#' using multiple spheres in covariate space. 
+#' using multiple spheres in covariate space.
 #'
-#' @param y A vector of the output values.
+#' @param y A vector of response values. Numeric `y` is treated as regression,
+#'   except when it has exactly two unique values in `{0, 1}`, which is
+#'   binary classification. Factor, character and logical vectors are treated as
+#'   classification: two levels give a binary probit model and three or more
+#'   levels give a multinomial probit model. The first factor level (or 0 for
+#'   numeric 0/1 responses) is the reference class. Missing values are not
+#'   allowed.
 #' @param x A matrix or data frame of the covariates. Character and factor columns
 #'   are treated as categorical variables and automatically converted to d-1 binary
 #'   indicator variables via one-hot encoding (with the first level as reference).
-#' @param m The number of tessellations.
+#' @param m The number of tessellations. For multinomial classification this is
+#'   the number of tessellations **per latent dimension** (there are \(K-1\)
+#'   latents for \(K\) classes).
 #' @param totalMCMCIter The number of iterations.
 #' @param mcmcBurnIn The number of burn in iterations.
-#' @param nu The degrees of freedom.
-#' @param q The quantile.
-#' @param k The number of centres.
+#' @param nu The degrees of freedom for the inverse-gamma prior on the residual
+#'   variance. Ignored for classification, where the latent residual variance is
+#'   fixed at 1.
+#' @param q The quantile used to set the inverse-gamma prior on the residual
+#'   variance. Ignored for classification.
+#' @param k Prior scale for tessellation output values. For regression,
+#'   \(\sigma_\mu = 0.5/(k\sqrt{m})\) on the scaled response. For classification,
+#'   \(\sigma_\mu = 3/(k\sqrt{m})\) on the latent probit scale.
 #' @param sd The standard deviation used in centre proposals.
 #' @param Omega Omega/(number of covariates) is the prior probability of
 #'   adding a dimension.
 #' @param LambdaRate The rate of the Poisson distribution for the number of centres.
-#' @param InitialSigma The method used to calculate the initial variance.
+#' @param InitialSigma The method used to calculate the initial residual
+#'   variance for regression (`"Linear"` or `"Naive"`). Ignored for
+#'   classification.
 #' @param thinning The thinning rate.
 #' @param metric Either "E" (Euclidean, default), "S" (Spherical), or "C" (Categorical).
 #' @param members If needed, indicates membership of covariates into different
@@ -64,7 +79,23 @@
 #'
 #' @return An AddiVortes object containing the posterior samples of the
 #' tessellations, dimensions and predictions, plus per-iteration trace
-#' statistics used by `traceplots()`.
+#' statistics used by `traceplots()`. Classification fits also store `task`,
+#' `classLevels`, `nLatents` and in-sample accuracy.
+#'
+#' @references
+#' Stone, A. and Gosling, J.P. (2025). AddiVortes: (Bayesian) additive Voronoi
+#' tessellations. *Journal of Computational and Graphical Statistics*.
+#'
+#' Stone, A.J., Ogundimu, E. and Gosling, J.P. (2026). Binary AddiVortes:
+#' (Bayesian) Additive Voronoi Tessellations for Binary Classification with an
+#' application to Predicting Home Mortgage Application Outcomes.
+#'
+#' Albert, J.H. and Chib, S. (1993). Bayesian analysis of binary and
+#' polychotomous response data. *Journal of the American Statistical
+#' Association*, 88(422), 669–679.
+#'
+#' Kindo, B.P., Wang, H. and Peña, E.A. (2016). Multinomial probit Bayesian
+#' additive regression trees. *Stat*, 5(1), 171–181.
 #'
 #' @examples
 #' \donttest{
@@ -102,9 +133,18 @@
 #'
 #' preds <- predict(fit2, x_test, showProgress = FALSE)
 #' test_rmse <- sqrt(mean((y_test - preds)^2))
+#'
+#' # Binary classification is selected automatically from a 0/1 or factor y
+#' set.seed(789)
+#' x_clf <- matrix(runif(80), 40, 2)
+#' y_clf <- factor(ifelse(x_clf[, 1] + x_clf[, 2] > 1, "yes", "no"))
+#' fit_clf <- AddiVortes(y_clf, x_clf, m = 8, totalMCMCIter = 80,
+#'                       mcmcBurnIn = 20, showProgress = FALSE)
+#' p_clf <- predict(fit_clf, x_clf, type = "response", showProgress = FALSE)
+#' cls_clf <- predict(fit_clf, x_clf, type = "class", showProgress = FALSE)
 #' }
 #'
-#' @importFrom stats var lm optim quantile runif rnorm dbinom dpois qnorm uniroot
+#' @importFrom stats var lm optim quantile runif rnorm dbinom dpois qnorm uniroot pnorm
 #' @export
 AddiVortes <- function(y, x, m = 200,
                        totalMCMCIter = 1200,
@@ -126,6 +166,19 @@ AddiVortes <- function(y, x, m = 200,
   # and causing prob = 1 in the dimension acceptance ratio (which produces 0/0 = NaN).
   force(Omega)
   ### Pre-processing data
+
+  if (NROW(x) != length(y)) {
+    stop("'y' must have length equal to the number of rows of 'x'.", call. = FALSE)
+  }
+  xOriginal <- x
+  responseInfo <- infer_response_type_internal(y)
+  task <- responseInfo$task
+  classLevels <- responseInfo$classLevels
+  yClass <- responseInfo$yClass
+  nLatents <- responseInfo$nLatents
+  mPerLatent <- m
+  mTotal <- m * nLatents
+  isClassification <- task != "regression"
 
   #### Encode categorical covariates -------------------------------------------
   if (!is.numeric(catScaling) || length(catScaling) != 1 || catScaling <= 0) {
@@ -183,10 +236,16 @@ AddiVortes <- function(y, x, m = 200,
   }
   
   #### Scaling x and y ---------------------------------------------------------
-  yScalingResult <- scaleData_internal(y)
-  yScaled <- yScalingResult$scaledData # Vector of values
-  yCentre <- yScalingResult$centres
-  yRange <- yScalingResult$ranges
+  if (isClassification) {
+    yScaled <- as.double(rep(0, length(y)))
+    yCentre <- 0
+    yRange <- 1
+  } else {
+    yScalingResult <- scaleData_internal(y)
+    yScaled <- yScalingResult$scaledData # Vector of values
+    yCentre <- yScalingResult$centres
+    yRange <- yScalingResult$ranges
+  }
   
   xScalingResult <- scaleData_internal(x)
   xScaled <- xScalingResult$scaledData # Matrix of values
@@ -235,11 +294,11 @@ AddiVortes <- function(y, x, m = 200,
   # Dimension set (A list of vectors with the covariates included in the tessellations);
   # and Tessellation Set (A list of matrices that give the
   #                       coordinates of the centres in the tessellations)
-  pred <- rep(list(matrix(mean(yScaled) / m)), m)
-  dim <- sapply(1:m, function(ignoredIndex) {
+  pred <- rep(list(matrix(if (isClassification) 0 else mean(yScaled) / m)), mTotal)
+  dim <- sapply(seq_len(mTotal), function(ignoredIndex) {
     list(sample(seq_len(ncol(x)), 1))
   })
-  tess <- sapply(1:m, function(ignoredIndex) {
+  tess <- sapply(seq_len(mTotal), function(ignoredIndex) {
     list(matrix(rnorm(1, 0, sd)))
   })
   ## Make sure that tessellation proposals are within the region, if periodic
@@ -281,34 +340,40 @@ AddiVortes <- function(y, x, m = 200,
   }
   
   #### Set-up MCMC -------------------------------------------------------------
-  # The variance that captures variability around the mean of the scaled y values.
-  SigmaSquaredMu <- (0.5 / (k * sqrt(m)))^2
-  
-  # Finding lambda
-  if (InitialSigma == "Naive") {
-    # Usually used if p is greater then n. Uses std dev of y to predict sigma.
-    SigmaSquaredHat <- var(yScaled)
+  # The variance that captures variability around the mean of the scaled y
+  # values (regression) or the latent probit scale (classification).
+  if (isClassification) {
+    SigmaSquaredMu <- (3 / (k * sqrt(m)))^2
+    lambda <- 1
   } else {
-    # Default method using residual standard deviation from a least-squared linear
-    # regression of y, to predict sigma.
-    multiLinear <- lm(yScaled ~ xScaled)
-    SigmaSquaredHat <- sum(multiLinear$residuals^2) /
-      (length(yScaled) - length(xScaled[1, ]) - 1)
+    SigmaSquaredMu <- (0.5 / (k * sqrt(m)))^2
+
+    # Finding lambda
+    if (InitialSigma == "Naive") {
+      # Usually used if p is greater then n. Uses std dev of y to predict sigma.
+      SigmaSquaredHat <- var(yScaled)
+    } else {
+      # Default method using residual standard deviation from a least-squared linear
+      # regression of y, to predict sigma.
+      multiLinear <- lm(yScaled ~ xScaled)
+      SigmaSquaredHat <- sum(multiLinear$residuals^2) /
+        (length(yScaled) - length(xScaled[1, ]) - 1)
+    }
+    lambda <- optim(
+      par = 1,
+      fittingFunction,
+      method = "Brent",
+      lower = 0.001,
+      upper = 100,
+      q = q, nu = nu,
+      SigmaSquaredHat = SigmaSquaredHat
+    )$par
   }
-  lambda <- optim(
-    par = 1,
-    fittingFunction,
-    method = "Brent",
-    lower = 0.001,
-    upper = 100,
-    q = q, nu = nu,
-    SigmaSquaredHat = SigmaSquaredHat
-  )$par
   
   # Normalise tess, dim and pred to plain R objects before passing to C++.
   # sapply may wrap results in lists or simplify to arrays; ensure each
   # element is a plain double matrix / integer vector / double vector.
-  init_tess <- lapply(seq_len(m), function(j) {
+  init_tess <- lapply(seq_len(mTotal), function(j) {
     t_j <- tess[[j]]
     if (is.list(t_j)) t_j <- t_j[[1]]
     m_j <- as.matrix(t_j)
@@ -338,10 +403,23 @@ AddiVortes <- function(y, x, m = 200,
         " covariates\n",
         sep = ""
     )
-    cat("Model configuration: ", m,
-        " tessellations, ", totalMCMCIter,
+    cat("Model configuration: ", mTotal,
+        " tessellation", if (mTotal == 1L) "" else "s",
+        if (isClassification && nLatents > 1L) {
+          paste0(" (", m, " per latent, ", nLatents, " latents)")
+        } else {
+          ""
+        },
+        ", ", totalMCMCIter,
         " total iterations (", mcmcBurnIn,
-        " burn-in)\n\n",
+        " burn-in)",
+        if (isClassification) {
+          paste0("\nTask: ", task, " classification with classes ",
+                 paste(classLevels, collapse = ", "))
+        } else {
+          ""
+        },
+        "\n\n",
         sep = ""
     )
     cat("Running MCMC...\n")
@@ -370,7 +448,10 @@ AddiVortes <- function(y, x, m = 200,
     init_pred,
     binaryCols_r,
     as.double(catScaling_r),
-    as.logical(showProgress)
+    as.logical(showProgress),
+    as.logical(isClassification),
+    if (isClassification) as.integer(yClass) else NULL,
+    as.integer(nLatents)
   )
   
   if (showProgress) cat("Done.\n\n")
@@ -383,21 +464,25 @@ AddiVortes <- function(y, x, m = 200,
   traceStats           <- mcmcResult$traceStats
   
   posteriorSamples <- ncol(predictionMatrix)
-  
-  # Finding the mean of the prediction over the iterations and then unscaling
-  # the predictions.
-  meanYhat <- if (posteriorSamples > 0) {
-    (rowSums(predictionMatrix) / posteriorSamples) * yRange + yCentre
-  } else {
-    rep(yCentre, length(y))
+
+  inSampleRmse <- NA_real_
+  inSampleAccuracy <- NA_real_
+  inSampleBrier <- NA_real_
+  if (task == "regression") {
+    meanYhat <- if (posteriorSamples > 0) {
+      (rowSums(predictionMatrix) / posteriorSamples) * yRange + yCentre
+    } else {
+      rep(yCentre, length(y))
+    }
+    inSampleRmse <- sqrt(mean((y - meanYhat)^2))
   }
-  
+
   # Create and return the AddiVortes object
   if (cat.onehot)
     this_enc <- catEncoding
   else
     this_enc <- NULL
-  new_AddiVortes(
+  fit <- new_AddiVortes(
     posteriorTess = outputPosteriorTess,
     posteriorDim = outputPosteriorDim,
     posteriorSigma = outputPosteriorSigma,
@@ -406,14 +491,35 @@ AddiVortes <- function(y, x, m = 200,
     xRanges = xRanges,
     yCentre = yCentre,
     yRange = yRange,
-    inSampleRmse = sqrt(mean((y - meanYhat)^2)),
+    inSampleRmse = inSampleRmse,
     metric = old_metric,
     members = old_members,
     metric_aug = metric,
     member_aug = members,
     catEncoding = this_enc,
-    traceStats = traceStats
+    traceStats = traceStats,
+    task = task,
+    classLevels = classLevels,
+    nLatents = nLatents,
+    mPerLatent = mPerLatent,
+    inSampleAccuracy = inSampleAccuracy,
+    inSampleBrier = inSampleBrier
   )
+
+  if (isClassification && posteriorSamples > 0) {
+    in_sample <- predict(fit, xOriginal, type = "response", showProgress = FALSE)
+    if (task == "binary") {
+      y01 <- as.numeric(yClass)
+      pred01 <- as.numeric(in_sample > 0.5)
+      fit$inSampleAccuracy <- mean(pred01 == y01)
+      fit$inSampleBrier <- mean((in_sample - y01)^2)
+    } else {
+      pred_idx <- max.col(in_sample, ties.method = "first")
+      fit$inSampleAccuracy <- mean(pred_idx == (yClass + 1L))
+    }
+  }
+
+  fit
 }
 
 countCovariateTypes_internal <- function(x, metric) {

--- a/R/AddiVortesFit.R
+++ b/R/AddiVortesFit.R
@@ -24,7 +24,8 @@
 #' @param classLevels Character vector of class labels for classification fits,
 #'   or `NULL` for regression.
 #' @param nLatents Number of latent probit dimensions. 1 for regression and
-#'   binary classification; \(K-1\) for \(K\)-class multinomial models.
+#'   binary classification; \eqn{K-1}{K-1} for \eqn{K}{K}-class multinomial
+#'   models.
 #' @param mPerLatent Number of tessellations per latent ensemble.
 #' @param inSampleAccuracy In-sample classification accuracy, or `NA` for
 #'   regression.
@@ -300,7 +301,7 @@ summary.AddiVortes <- function(object, ...) {
 #'   the mean prediction (class probabilities for classification). `"quantile"`
 #'   returns the quantiles specified by `quantiles`. `"class"` returns predicted
 #'   class labels (classification only). `"link"` returns the latent sum of
-#'   tessellations \(G(x)\).
+#'   tessellations \eqn{G(x)}{G(x)}.
 #' @param quantiles A numeric vector of probabilities to
 #'   compute for the predictions when `type = "quantile"`.
 #' @param interval The type of interval calculation. The default `"credible"`
@@ -314,11 +315,11 @@ summary.AddiVortes <- function(object, ...) {
 #'
 #' @return
 #' If `type = "response"`, a numeric vector of mean predictions for regression
-#' or binary classification, or an \(n \times K\) probability matrix for
-#' multinomial classification. If `type = "quantile"`, a matrix of quantiles
+#' or binary classification, or an \eqn{n \times K}{n x K} probability matrix
+#' for multinomial classification. If `type = "quantile"`, a matrix of quantiles
 #' (binary/regression) or a named list of such matrices (multinomial). If
 #' `type = "class"`, a factor of predicted labels. If `type = "link"`, the
-#' latent function \(G(x)\).
+#' latent function \eqn{G(x)}{G(x)}.
 #'
 #' @details
 #' This function relies on the internal helper function `applyScaling_internal`
@@ -337,9 +338,9 @@ summary.AddiVortes <- function(object, ...) {
 #' not defined; use `type = "quantile"` for credible intervals on probabilities.
 #'
 #' For binary classification, `"response"` is the posterior mean of
-#' \(\Phi(G^{(s)}(x))\). For multinomial classification, class probabilities
-#' are estimated from independent \(N(G, I)\) latents, with the first class
-#' as the reference.
+#' \eqn{\Phi(G^{(s)}(x))}{Phi(G^(s)(x))}. For multinomial classification, class
+#' probabilities are estimated from independent \eqn{N(G, I)}{N(G, I)} latents,
+#' with the first class as the reference.
 #'
 #' @examples
 #' \donttest{

--- a/R/AddiVortesFit.R
+++ b/R/AddiVortesFit.R
@@ -20,6 +20,16 @@
 #'   \code{encodeCategories_internal}, or \code{NULL} if no categorical covariates
 #'   were present.
 #' @param traceStats Optional data frame of per-iteration MCMC trace statistics.
+#' @param task The modelling task: `"regression"`, `"binary"` or `"multinomial"`.
+#' @param classLevels Character vector of class labels for classification fits,
+#'   or `NULL` for regression.
+#' @param nLatents Number of latent probit dimensions. 1 for regression and
+#'   binary classification; \(K-1\) for \(K\)-class multinomial models.
+#' @param mPerLatent Number of tessellations per latent ensemble.
+#' @param inSampleAccuracy In-sample classification accuracy, or `NA` for
+#'   regression.
+#' @param inSampleBrier In-sample Brier score for binary classification, or `NA`
+#'   otherwise.
 #'
 #' @return An object of class AddiVortes.
 #' @export
@@ -31,9 +41,19 @@ new_AddiVortes <- function(posteriorTess, posteriorDim,
                            metric_aug = "E",
                            member_aug = rep(1, length(xCentres)),
                            catEncoding = NULL,
-                           traceStats = NULL) {
+                           traceStats = NULL,
+                           task = "regression",
+                           classLevels = NULL,
+                           nLatents = 1L,
+                           mPerLatent = NA_integer_,
+                           inSampleAccuracy = NA_real_,
+                           inSampleBrier = NA_real_) {
   member_length <- sapply(unique(member_aug), function(x) sum(member_aug == x))
   metric_type <- sapply(unique(member_aug), function(x) metric_aug[which(member_aug == x)[1]])
+  if (is.na(mPerLatent)) {
+    n_tess <- if (length(posteriorTess) > 0) length(posteriorTess[[1]]) else 0L
+    mPerLatent <- as.integer(n_tess / max(1L, nLatents))
+  }
   structure(
     list(
       posteriorTess = posteriorTess,
@@ -50,7 +70,13 @@ new_AddiVortes <- function(posteriorTess, posteriorDim,
       metric_red = metric_type,
       member_red = member_length,
       catEncoding = catEncoding,
-      traceStats = traceStats
+      traceStats = traceStats,
+      task = task,
+      classLevels = classLevels,
+      nLatents = as.integer(nLatents),
+      mPerLatent = as.integer(mPerLatent),
+      inSampleAccuracy = inSampleAccuracy,
+      inSampleBrier = inSampleBrier
     ),
     class = "AddiVortes"
   )
@@ -88,7 +114,14 @@ print.AddiVortes <- function(x, ...) {
     stop("`x` must be an object of class 'AddiVortes'.")
   }
 
-  cat("AddiVortes Model\n")
+  is_class <- isClassification_internal(x)
+  if (isTRUE(x$task == "binary")) {
+    cat("AddiVortes Binary Classification Model\n")
+  } else if (isTRUE(x$task == "multinomial")) {
+    cat("AddiVortes Multinomial Classification Model\n")
+  } else {
+    cat("AddiVortes Model\n")
+  }
   cat("================\n\n")
 
   # Model equation representation
@@ -120,7 +153,22 @@ print.AddiVortes <- function(x, ...) {
   cat("Number of covariates:     ", num_covariates, "\n")
   cat("Number of tessellations:  ", num_tessellations, "\n")
   cat("Posterior samples:        ", num_samples, "\n")
-  cat("In-sample RMSE:           ", round(x$inSampleRmse, 4), "\n\n")
+  if (is_class) {
+    cat("Task:                     ", x$task, "\n")
+    cat("Classes:                  ", paste(x$classLevels, collapse = ", "), "\n")
+    if (!is.null(x$nLatents) && x$nLatents > 1L) {
+      cat("Latent dimensions:        ", x$nLatents, "\n")
+    }
+    if (!is.na(x$inSampleAccuracy)) {
+      cat("In-sample accuracy:       ", round(x$inSampleAccuracy, 4), "\n")
+    }
+    if (!is.na(x$inSampleBrier)) {
+      cat("In-sample Brier score:    ", round(x$inSampleBrier, 4), "\n")
+    }
+    cat("\n")
+  } else {
+    cat("In-sample RMSE:           ", round(x$inSampleRmse, 4), "\n\n")
+  }
 
   # Scaling information
   cat("Covariate Scaling:\n")
@@ -131,9 +179,13 @@ print.AddiVortes <- function(x, ...) {
   )
   print(scaling_df, row.names = FALSE)
 
-  cat("\nOutput Scaling:\n")
-  cat("Centre: ", round(x$yCentre, 4), "\n")
-  cat("Range:  ", round(x$yRange, 4), "\n\n")
+  if (is_class) {
+    cat("\nLatent scale: probit (sigma = 1; response is not scaled)\n\n")
+  } else {
+    cat("\nOutput Scaling:\n")
+    cat("Centre: ", round(x$yCentre, 4), "\n")
+    cat("Range:  ", round(x$yRange, 4), "\n\n")
+  }
 
   # Additional model information
   if (num_samples > 0) {
@@ -236,30 +288,37 @@ summary.AddiVortes <- function(object, ...) {
 #'
 #' @description
 #' Predicts outcomes for new data using a fitted `AddiVortes` model object.
-#' It can return mean predictions, quantiles and optionally calculate the
-#' Root Mean Squared Error (RMSE) if true outcomes are provided.
+#' Regression fits return means or quantiles of the response. Classification
+#' fits return class probabilities, class labels, latent-scale values, or
+#' quantiles of the class probabilities.
 #'
 #' @param object An object of class `AddiVortes`, typically the result of a
 #'   call to `AddiVortes()`.
 #' @param newdata A matrix of covariates for the new test set. The number of
 #'   columns must match the original training data.
 #' @param type The type of prediction required. The default `"response"` gives
-#'   the mean prediction. The alternative `"quantile"` returns the quantiles
-#'   specified by the `quantiles` argument.
+#'   the mean prediction (class probabilities for classification). `"quantile"`
+#'   returns the quantiles specified by `quantiles`. `"class"` returns predicted
+#'   class labels (classification only). `"link"` returns the latent sum of
+#'   tessellations \(G(x)\).
 #' @param quantiles A numeric vector of probabilities to
 #'   compute for the predictions when `type = "quantile"`.
 #' @param interval The type of interval calculation. The default `"credible"`
 #'   accounts only for uncertainty in the mean (similar to `lm`'s confidence interval).
 #'   The alternative `"prediction"` also includes the model's error variance,
-#'   producing wider intervals (similar to `lm`'s prediction interval).
+#'   producing wider intervals (similar to `lm`'s prediction interval). Not used
+#'   for classification models.
 #' @param showProgress Logical; if TRUE, a progress bar is shown during prediction.
 #' @param ... Further arguments passed to or from other methods (currently
 #' unused).
 #'
 #' @return
-#' If `type = "response"`, a numeric vector of mean predictions.
-#' If `type = "quantile"`, a matrix where each row corresponds to an observation
-#' in `newdata` and each column to a quantile.
+#' If `type = "response"`, a numeric vector of mean predictions for regression
+#' or binary classification, or an \(n \times K\) probability matrix for
+#' multinomial classification. If `type = "quantile"`, a matrix of quantiles
+#' (binary/regression) or a named list of such matrices (multinomial). If
+#' `type = "class"`, a factor of predicted labels. If `type = "link"`, the
+#' latent function \(G(x)\).
 #'
 #' @details
 #' This function relies on the internal helper function `applyScaling_internal`
@@ -273,7 +332,14 @@ summary.AddiVortes <- function(object, ...) {
 #' additional Gaussian noise with variance equal to the sampled sigma squared
 #' from the posterior. This accounts for the inherent variability in individual
 #' predictions, not just uncertainty in the mean function. The noise is added
-#' in the scaled space before unscaling predictions.
+#' in the scaled space before unscaling predictions. Classification uses a
+#' probit link with residual variance fixed at 1, so prediction intervals are
+#' not defined; use `type = "quantile"` for credible intervals on probabilities.
+#'
+#' For binary classification, `"response"` is the posterior mean of
+#' \(\Phi(G^{(s)}(x))\). For multinomial classification, class probabilities
+#' are estimated from independent \(N(G, I)\) latents, with the first class
+#' as the reference.
 #'
 #' @examples
 #' \donttest{
@@ -307,11 +373,11 @@ summary.AddiVortes <- function(object, ...) {
 #' mean(pred_pred[, 2] - pred_pred[, 1]) > mean(pred_conf[, 2] - pred_conf[, 1])
 #' }
 #'
-#' @importFrom stats rnorm quantile
+#' @importFrom stats rnorm quantile pnorm
 #' @export
 #' @method predict AddiVortes
 predict.AddiVortes <- function(object, newdata,
-                               type = c("response", "quantile"),
+                               type = c("response", "quantile", "class", "link"),
                                quantiles = c(0.025, 0.975),
                                interval = c("credible", "prediction"),
                                showProgress = interactive(),
@@ -327,6 +393,19 @@ predict.AddiVortes <- function(object, newdata,
     stop("`newdata` must be a matrix or data frame.")
   }
 
+  is_class <- isClassification_internal(object)
+  if (type == "class" && !is_class) {
+    stop("`type = \"class\"` is only valid for classification models.",
+         call. = FALSE)
+  }
+  if (is_class && interval == "prediction") {
+    stop(
+      "Prediction intervals are not used for classification models; ",
+      "use type = \"quantile\" for credible intervals on class probabilities.",
+      call. = FALSE
+    )
+  }
+
   # Apply categorical encoding if the model was trained with categorical covariates
   if (!is.null(object$catEncoding)) {
     if (ncol(newdata) != object$catEncoding$origNCols) {
@@ -337,9 +416,6 @@ predict.AddiVortes <- function(object, newdata,
     encResult <- encodeCategories_internal(newdata, encoding = object$catEncoding)
     newdata <- encResult$encoded
   } else {
-    # if (!is.matrix(newdata)) {
-    #   stop("`newdata` must be a matrix.")
-    # }
     if (ncol(newdata) != length(object$xCentres)) {
       stop("Number of columns in `newdata` does not match the original training data.")
     }
@@ -400,6 +476,14 @@ predict.AddiVortes <- function(object, newdata,
     )
   }
 
+  if (is_class) {
+    G_list <- latentLinkMatrices_internal(object, xNewScaled, showProgress)
+    if (showProgress) cat("Done.\n\n")
+    return(summariseClassificationPredictions_internal(
+      object, G_list, type, quantiles
+    ))
+  }
+
   # Single compiled pass over all draws and tessellations
   newTestDataPredictionsMatrix <- .Call(
     "addi_vortes_predict_cpp",
@@ -426,7 +510,7 @@ predict.AddiVortes <- function(object, newdata,
   if (showProgress) cat("Done.\n\n")
 
   # --- Unscale and summarise predictions ---
-  if (type == "response") {
+  if (type == "link" || type == "response") {
     predictions <- rowMeans(newTestDataPredictionsMatrix) * object$yRange + object$yCentre
   } else if (type == "quantile") {
     quantileYhatNewScaled <- apply(newTestDataPredictionsMatrix, 1, quantile,
@@ -436,6 +520,64 @@ predict.AddiVortes <- function(object, newdata,
   }
 
   return(predictions)
+}
+
+#' @title Summarise classification predictions from latent G draws
+#'
+#' @keywords internal
+#' @noRd
+summariseClassificationPredictions_internal <- function(object, G_list, type,
+                                                        quantiles) {
+  class_levels <- object$classLevels
+  if (object$task == "binary") {
+    g_mat <- G_list[[1]]
+    p_mat <- stats::pnorm(g_mat)
+    mean_p <- rowMeans(p_mat)
+    if (type == "link") {
+      return(rowMeans(g_mat))
+    }
+    if (type == "response") {
+      return(mean_p)
+    }
+    if (type == "class") {
+      idx <- ifelse(mean_p > 0.5, 2L, 1L)
+      return(factor(class_levels[idx], levels = class_levels))
+    }
+    quantile_p <- apply(p_mat, 1, stats::quantile, probs = quantiles, na.rm = TRUE)
+    return(t(quantile_p))
+  }
+
+  n_latents <- length(G_list)
+  if (type == "link") {
+    link_mat <- vapply(G_list, rowMeans, numeric(nrow(G_list[[1]])))
+    colnames(link_mat) <- paste0("latent", seq_len(n_latents))
+    return(link_mat)
+  }
+
+  probs <- multinomialProbabilities_internal(
+    G_list,
+    nMC = 32L,
+    perDraw = type == "quantile"
+  )
+  colnames(probs$mean) <- class_levels
+  if (type == "response") {
+    return(probs$mean)
+  }
+  if (type == "class") {
+    idx <- max.col(probs$mean, ties.method = "first")
+    return(factor(class_levels[idx], levels = class_levels))
+  }
+
+  quantile_list <- vector("list", length(class_levels))
+  names(quantile_list) <- class_levels
+  n_draw <- dim(probs$draw)[3]
+  n_obs <- nrow(probs$mean)
+  for (k in seq_along(class_levels)) {
+    draw_k <- matrix(probs$draw[, k, ], nrow = n_obs, ncol = n_draw)
+    quantile_list[[k]] <- t(apply(draw_k, 1, stats::quantile,
+                                  probs = quantiles, na.rm = TRUE))
+  }
+  quantile_list
 }
 
 extractErrorStandardDeviationTrace_internal <- function(x, sigma_trace = NULL,
@@ -718,8 +860,9 @@ traceplots <- function(x, ...) {
 #'
 #' @param x An object of class `AddiVortes`, typically the result of a
 #'   call to `AddiVortes()`.
-#' @param x_train A matrix of the original training covariates.
-#' @param y_train A numeric vector of the original training true outcomes.
+#' @param x_train A matrix or data frame of the original training covariates.
+#' @param y_train The original training response. Numeric for regression;
+#'   factor, character, logical or 0/1 numeric for classification.
 #' @param sigma_trace An optional numeric vector of sigma values from MCMC samples.
 #'   If not provided, the method will attempt to extract the posterior error
 #'   standard deviation from the model object.
@@ -770,13 +913,14 @@ plot.AddiVortes <- function(x, x_train, y_train, sigma_trace = NULL,
   if (missing(x_train) || missing(y_train)) {
     stop("`x_train` and `y_train` must be provided for diagnostic plots.")
   }
-  if (!is.matrix(x_train)) {
-    stop("`x_train` must be a matrix.")
+  if (!is.matrix(x_train) && !is.data.frame(x_train)) {
+    stop("`x_train` must be a matrix or data frame.")
   }
-  if (!is.numeric(y_train)) {
+  is_class <- isClassification_internal(x)
+  if (!is_class && !is.numeric(y_train)) {
     stop("`y_train` must be a numeric vector.")
   }
-  if (nrow(x_train) != length(y_train)) {
+  if (NROW(x_train) != length(y_train)) {
     stop("The number of rows in `x_train` must match the length of `y_train`.")
   }
   if (length(x$posteriorTess) == 0) {
@@ -785,6 +929,9 @@ plot.AddiVortes <- function(x, x_train, y_train, sigma_trace = NULL,
 
   # Validate which parameter
   which <- intersect(which, 1:4)
+  if (is_class) {
+    which <- setdiff(which, 2L)
+  }
   if (length(which) == 0) {
     stop("`which` must contain values between 1 and 4.")
   }
@@ -804,9 +951,32 @@ plot.AddiVortes <- function(x, x_train, y_train, sigma_trace = NULL,
   }
 
   # Generate predictions for residuals analysis
+  y_pred_prob <- NULL
   if (any(which %in% c(1, 4))) {
-    y_pred_mean <- predict(x, newdata = x_train, type = "response")
-    residuals <- y_train - y_pred_mean
+    y_pred_mean <- predict(x, newdata = x_train, type = "response",
+                           showProgress = FALSE)
+    if (isTRUE(x$task == "binary")) {
+      y01 <- if (is.numeric(y_train)) {
+        as.numeric(y_train == 1 | y_train == x$classLevels[2])
+      } else {
+        as.numeric(as.character(y_train) == x$classLevels[2] |
+                     y_train == x$classLevels[2])
+      }
+      if (is.logical(y_train)) {
+        y01 <- as.numeric(y_train)
+      }
+      y_pred_prob <- y_pred_mean
+      residuals <- y01 - y_pred_mean
+    } else if (isTRUE(x$task == "multinomial")) {
+      y_pred_prob <- y_pred_mean
+      true_idx <- match(as.character(y_train), x$classLevels)
+      if (anyNA(true_idx)) {
+        true_idx <- as.integer(factor(y_train, levels = x$classLevels))
+      }
+      residuals <- y_pred_mean[cbind(seq_len(nrow(y_pred_mean)), true_idx)]
+    } else {
+      residuals <- y_train - y_pred_mean
+    }
   }
 
   # Calculate tessellation statistics across samples
@@ -823,26 +993,43 @@ plot.AddiVortes <- function(x, x_train, y_train, sigma_trace = NULL,
       readline()
     }
 
-    plot(y_pred_mean, residuals,
-      xlab = "Fitted Values",
-      ylab = "Residuals",
-      main = "Residuals vs Fitted",
-      pch = 19, col = "darkblue", cex = 0.8,
-      ...
-    )
+    if (isTRUE(x$task == "multinomial")) {
+      plot(seq_along(residuals), residuals,
+        xlab = "Observation",
+        ylab = "Predicted Probability of True Class",
+        main = "Probability of Observed Class",
+        pch = 19, col = "darkblue", cex = 0.8,
+        ylim = c(0, 1),
+        ...
+      )
+      abline(h = 1 / length(x$classLevels), col = "red", lty = 2, lwd = 2)
+    } else {
+      plot(y_pred_mean, residuals,
+        xlab = if (is_class) "Fitted Probability" else "Fitted Values",
+        ylab = if (is_class) "Observed minus Probability" else "Residuals",
+        main = "Residuals vs Fitted",
+        pch = 19, col = "darkblue", cex = 0.8,
+        ...
+      )
 
-    # Add horizontal line at y = 0
-    abline(h = 0, col = "red", lty = 2, lwd = 2)
+      # Add horizontal line at y = 0
+      abline(h = 0, col = "red", lty = 2, lwd = 2)
 
-    # Add smoothed trend line
-    if (length(y_pred_mean) > 3) {
-      smooth_line <- lowess(y_pred_mean, residuals)
-      lines(smooth_line, col = "orange", lwd = 2)
+      # Add smoothed trend line
+      if (length(y_pred_mean) > 3) {
+        smooth_line <- lowess(y_pred_mean, residuals)
+        lines(smooth_line, col = "orange", lwd = 2)
+      }
     }
 
-    # Add RMSE annotation
-    rmse_text <- paste("RMSE =", round(x$inSampleRmse, 4))
-    legend("topright", legend = rmse_text, bty = "n", cex = 0.9)
+    # Add RMSE or accuracy annotation
+    if (is_class) {
+      acc_text <- paste("Accuracy =", round(x$inSampleAccuracy, 4))
+      legend("topright", legend = acc_text, bty = "n", cex = 0.9)
+    } else {
+      rmse_text <- paste("RMSE =", round(x$inSampleRmse, 4))
+      legend("topright", legend = rmse_text, bty = "n", cex = 0.9)
+    }
   }
 
   # --- Plot 2: Sigma Trace ---
@@ -919,56 +1106,88 @@ plot.AddiVortes <- function(x, x_train, y_train, sigma_trace = NULL,
       readline()
     }
 
-    # Get quantile predictions for uncertainty
-    y_pred_quantiles <- predict(x,
-      newdata = x_train, type = "quantile",
-      quantiles = c(0.025, 0.975)
-    )
+    if (isTRUE(x$task == "binary")) {
+      y01 <- if (is.logical(y_train)) {
+        as.numeric(y_train)
+      } else if (is.numeric(y_train) && all(y_train %in% c(0, 1))) {
+        as.numeric(y_train)
+      } else {
+        as.numeric(as.character(y_train) == x$classLevels[2])
+      }
+      plot(y01, y_pred_prob,
+        xlab = "Observed Class (0/1)",
+        ylab = "Predicted Probability",
+        main = "Predicted Probability vs Observed",
+        pch = 19, col = "darkblue", cex = 0.8,
+        ylim = c(0, 1),
+        ...
+      )
+      abline(h = 0.5, col = "red", lty = 2, lwd = 2)
+    } else if (isTRUE(x$task == "multinomial")) {
+      true_idx <- match(as.character(y_train), x$classLevels)
+      p_true <- y_pred_prob[cbind(seq_len(nrow(y_pred_prob)), true_idx)]
+      plot(seq_along(p_true), p_true,
+        xlab = "Observation",
+        ylab = "Predicted Probability of True Class",
+        main = "Probability of Observed Class",
+        pch = 19, col = "darkblue", cex = 0.8,
+        ylim = c(0, 1),
+        ...
+      )
+      abline(h = 1 / length(x$classLevels), col = "red", lty = 2, lwd = 2)
+    } else {
+      # Get quantile predictions for uncertainty
+      y_pred_quantiles <- predict(x,
+        newdata = x_train, type = "quantile",
+        quantiles = c(0.025, 0.975),
+        showProgress = FALSE
+      )
 
-    # Create the scatter plot
-    plot(y_train, y_pred_mean,
-      xlab = "Observed Values",
-      ylab = "Predicted Values",
-      main = "Predicted vs Observed",
-      pch = 19, col = "darkblue", cex = 0.8,
-      xlim = range(c(y_train, y_pred_mean)),
-      ylim = range(c(y_train, y_pred_mean)),
-      ...
-    )
+      # Create the scatter plot
+      plot(y_train, y_pred_mean,
+        xlab = "Observed Values",
+        ylab = "Predicted Values",
+        main = "Predicted vs Observed",
+        pch = 19, col = "darkblue", cex = 0.8,
+        xlim = range(c(y_train, y_pred_mean)),
+        ylim = range(c(y_train, y_pred_mean)),
+        ...
+      )
 
-    # Add the line of equality (perfect prediction)
-    abline(a = 0, b = 1, col = "red", lwd = 2, lty = 2)
+      # Add the line of equality (perfect prediction)
+      abline(a = 0, b = 1, col = "red", lwd = 2, lty = 2)
 
-    # Add uncertainty intervals
-    for (i in seq_along(y_train)) {
-      segments(y_train[i], y_pred_quantiles[i, 1],
-        y_train[i], y_pred_quantiles[i, 2],
-        col = "lightblue", lwd = 1
+      # Add uncertainty intervals
+      for (i in seq_along(y_train)) {
+        segments(y_train[i], y_pred_quantiles[i, 1],
+          y_train[i], y_pred_quantiles[i, 2],
+          col = "lightblue", lwd = 1
+        )
+      }
+
+      # Calculate and display R-squared
+      ss_res <- sum(residuals^2)
+      ss_tot <- sum((y_train - mean(y_train))^2)
+      r_squared <- 1 - (ss_res / ss_tot)
+
+      legend("topleft",
+        legend = c(
+          "Perfect Prediction",
+          "95% Prediction Intervals"
+        ),
+        col = c("red", "lightblue"),
+        lty = c(2, 1),
+        lwd = c(2, 1),
+        pch = c(NA, NA), cex = 0.9, bty = "n"
+      )
+      legend("bottomright",
+        legend = c(paste("R^2 =", round(r_squared, 3))),
+        col = c("black"),
+        lty = c(NA),
+        lwd = c(NA),
+        pch = c(NA), cex = 0.9, bty = "n"
       )
     }
-
-    # Calculate and display R-squared
-    ss_res <- sum(residuals^2)
-    ss_tot <- sum((y_train - mean(y_train))^2)
-    r_squared <- 1 - (ss_res / ss_tot)
-
-    legend("topleft",
-      legend = c(
-        "Perfect Prediction",
-        "95% Prediction Intervals"
-      ),
-      col = c("red", "lightblue"),
-      lty = c(2, 1),
-      lwd = c(2, 1),
-      pch = c(NA, NA), cex = 0.9, bty = "n"
-    )
-    legend("bottomright",
-      legend = c(paste("R^2 =", round(r_squared, 3))),
-      col = c("black"),
-      lty = c(NA),
-      lwd = c(NA),
-      pch = c(NA), cex = 0.9, bty = "n"
-    )
   }
 
   # Return invisibly

--- a/R/AddiVortesFit.R
+++ b/R/AddiVortesFit.R
@@ -301,7 +301,8 @@ summary.AddiVortes <- function(object, ...) {
 #'   the mean prediction (class probabilities for classification). `"quantile"`
 #'   returns the quantiles specified by `quantiles`. `"class"` returns predicted
 #'   class labels (classification only). `"link"` returns the latent sum of
-#'   tessellations \eqn{G(x)}{G(x)}.
+#'   tessellations \eqn{G(x)}{G(x)} on the model scale before any response
+#'   unscaling.
 #' @param quantiles A numeric vector of probabilities to
 #'   compute for the predictions when `type = "quantile"`.
 #' @param interval The type of interval calculation. The default `"credible"`
@@ -319,7 +320,8 @@ summary.AddiVortes <- function(object, ...) {
 #' for multinomial classification. If `type = "quantile"`, a matrix of quantiles
 #' (binary/regression) or a named list of such matrices (multinomial). If
 #' `type = "class"`, a factor of predicted labels. If `type = "link"`, the
-#' latent function \eqn{G(x)}{G(x)}.
+#' latent function \eqn{G(x)}{G(x)} on the model scale before response
+#' unscaling.
 #'
 #' @details
 #' This function relies on the internal helper function `applyScaling_internal`
@@ -336,6 +338,10 @@ summary.AddiVortes <- function(object, ...) {
 #' in the scaled space before unscaling predictions. Classification uses a
 #' probit link with residual variance fixed at 1, so prediction intervals are
 #' not defined; use `type = "quantile"` for credible intervals on probabilities.
+#'
+#' For regression, `"response"` unscales predictions back to the original
+#' response units, while `"link"` returns the posterior mean of the latent
+#' scaled function \eqn{G(x)}{G(x)}.
 #'
 #' For binary classification, `"response"` is the posterior mean of
 #' \eqn{\Phi(G^{(s)}(x))}{Phi(G^(s)(x))}. For multinomial classification, class
@@ -511,7 +517,9 @@ predict.AddiVortes <- function(object, newdata,
   if (showProgress) cat("Done.\n\n")
 
   # --- Unscale and summarise predictions ---
-  if (type == "link" || type == "response") {
+  if (type == "link") {
+    predictions <- rowMeans(newTestDataPredictionsMatrix)
+  } else if (type == "response") {
     predictions <- rowMeans(newTestDataPredictionsMatrix) * object$yRange + object$yCentre
   } else if (type == "quantile") {
     quantileYhatNewScaled <- apply(newTestDataPredictionsMatrix, 1, quantile,
@@ -579,6 +587,16 @@ summariseClassificationPredictions_internal <- function(object, G_list, type,
                                   probs = quantiles, na.rm = TRUE))
   }
   quantile_list
+}
+
+binaryObservedResponse_internal <- function(y, class_levels) {
+  if (is.logical(y)) {
+    return(as.numeric(y))
+  }
+  if (is.numeric(y) && all(y %in% c(0, 1))) {
+    return(as.numeric(y))
+  }
+  as.numeric(as.character(y) == class_levels[2])
 }
 
 extractErrorStandardDeviationTrace_internal <- function(x, sigma_trace = NULL,
@@ -957,15 +975,7 @@ plot.AddiVortes <- function(x, x_train, y_train, sigma_trace = NULL,
     y_pred_mean <- predict(x, newdata = x_train, type = "response",
                            showProgress = FALSE)
     if (isTRUE(x$task == "binary")) {
-      y01 <- if (is.numeric(y_train)) {
-        as.numeric(y_train == 1 | y_train == x$classLevels[2])
-      } else {
-        as.numeric(as.character(y_train) == x$classLevels[2] |
-                     y_train == x$classLevels[2])
-      }
-      if (is.logical(y_train)) {
-        y01 <- as.numeric(y_train)
-      }
+      y01 <- binaryObservedResponse_internal(y_train, x$classLevels)
       y_pred_prob <- y_pred_mean
       residuals <- y01 - y_pred_mean
     } else if (isTRUE(x$task == "multinomial")) {
@@ -1108,13 +1118,7 @@ plot.AddiVortes <- function(x, x_train, y_train, sigma_trace = NULL,
     }
 
     if (isTRUE(x$task == "binary")) {
-      y01 <- if (is.logical(y_train)) {
-        as.numeric(y_train)
-      } else if (is.numeric(y_train) && all(y_train %in% c(0, 1))) {
-        as.numeric(y_train)
-      } else {
-        as.numeric(as.character(y_train) == x$classLevels[2])
-      }
+      y01 <- binaryObservedResponse_internal(y_train, x$classLevels)
       plot(y01, y_pred_prob,
         xlab = "Observed Class (0/1)",
         ylab = "Predicted Probability",

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 ## Overview
 
-AddiVortes implements the **Bayesian Additive Voronoi Tessellation** model for machine learning regression and non-parametric statistical modelling. This R package provides a flexible alternative to **BART (Bayesian Additive Regression Trees)**, using Voronoi tessellations instead of trees for spatial partitioning.
+AddiVortes implements the **Bayesian Additive Voronoi Tessellation** model for machine learning regression, classification and non-parametric statistical modelling. This R package provides a flexible alternative to **BART (Bayesian Additive Regression Trees)**, using Voronoi tessellations instead of trees for spatial partitioning.
 
 ## Key Features
 
 - **Machine Learning Regression**: Advanced Bayesian regression modelling for complex datasets
-- **Alternative to BART**: Uses Voronoi tessellations instead of trees for more flexible spatial modeling
+- **Classification**: Binary and multi-category probit models, chosen automatically from the response
+- **Alternative to BART**: Uses Voronoi tessellations instead of trees for more flexible spatial modelling
 - **Spatial Data Analysis**: Excellent for geographic and spatial datasets
 - **Non-parametric Modelling**: No assumptions about functional form
 - **Bayesian Framework**: Full posterior inference with uncertainty quantification
@@ -18,6 +19,7 @@ AddiVortes implements the **Bayesian Additive Voronoi Tessellation** model for m
 AddiVortes is particularly well-suited for:
 
 - **Spatial regression** and geographic data analysis
+- **Binary and multi-category classification** with posterior class probabilities
 - **Machine learning** tasks requiring interpretable models
 - **Non-parametric regression** where the functional form is unknown
 - **Bayesian modelling** with uncertainty quantification
@@ -41,17 +43,20 @@ library(AddiVortes)
 # X <- your_predictors
 # y <- your_response
 
-# Fit the AddiVortes model
-# model <- AddiVortes(X, y)
+# Fit the AddiVortes model (regression or classification, from y)
+# model <- AddiVortes(y, X)
 
 # Make predictions
 # predictions <- predict(model, newdata = X_test)
+# For classification, type = "response" gives probabilities
+# and type = "class" gives labels
 ```
 
 ## Documentation
 
 - [Getting Started Guide](https://johnpaulgosling.github.io/AddiVortes/articles/introduction.html)
 - [Prediction Examples](https://johnpaulgosling.github.io/AddiVortes/articles/prediction.html)
+- [Classification](https://johnpaulgosling.github.io/AddiVortes/articles/classification.html)
 - [Function Reference](https://johnpaulgosling.github.io/AddiVortes/reference/)
 
 ## Comparison with BART

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,9 +5,10 @@ template:
 home:
   title: "AddiVortes: Bayesian Machine Learning Alternative to BART"
   description: >
-    Bayesian Additive Voronoi Tessellations for machine learning regression.
-    A flexible alternative to BART using spatial tessellations for 
-    non-parametric Bayesian modeling and spatial data analysis.
+    Bayesian Additive Voronoi Tessellations for machine learning regression
+    and classification. A flexible alternative to BART using spatial
+    tessellations for non-parametric Bayesian modelling and spatial data
+    analysis.
 
 navbar:
   title: "AddiVortes"
@@ -24,6 +25,8 @@ navbar:
           href: articles/spherical.html
         - text: "Using Categorical Covariates with AddiVortes"
           href: articles/categorical.html
+        - text: "Classification with AddiVortes"
+          href: articles/classification.html
 
 reference:
   - title: "Package Overview"

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,26 +1,28 @@
-## Submission of AddiVortes 0.6.9
+## Submission of AddiVortes 1.0.0
 
-This resubmission addresses two CRAN check failures from earlier 0.6.8/0.6.9 builds:
-
-1. AddressSanitizer heap-buffer-overflow in `propose_internal()`
-   (spherical vignette rebuild on SAN / clang-ASAN builders).
-2. Install WARNING from unused variable `-Wunused-variable` in
-   `log_acceptance_components()`.
+This release adds binary and multinomial probit classification, chosen
+automatically from the response, alongside the existing regression model.
 
 ## Test environments
 
-* local Ubuntu 24.04, R 4.6.1
-* previous CRAN SAN / clang-ASAN reports for 0.6.8 (ASan abort, now fixed)
+* GitHub Actions: macOS-latest (R-release), Windows-latest (R-release),
+  Ubuntu-latest (R-devel, R-release, R-oldrel)
+* local Ubuntu, R 4.3.3
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 notes on CRAN-like builders.
+
+On some Ubuntu and macOS installations, `R CMD check --as-cran` reports:
 
 * checking compilation flags used ... NOTE
   Compilation used the following non-portable flag(s):
-    ‘-mno-omit-leaf-frame-pointer’
+    ‘-Werror=format-security’ ‘-Wformat’ ‘-Wp,-D_FORTIFY_SOURCE=3’
+    ‘-Wp,-D_GLIBCXX_ASSERTIONS’ ‘-march=x86-64-v3’ ‘-mpclmul’
 
-This flag is injected by the system R installation on Ubuntu
-(`/usr/lib/R/etc/Makeconf`), not by this package. The package has no
-`src/Makevars` and sets no compiler flags of its own. The NOTE does not
-appear on CRAN's builders.
+Those flags come from the system R `Makeconf` (for example
+`/usr/lib/R/etc/Makeconf` on Ubuntu, or the macOS R binary used on GitHub
+Actions). This package has no `src/Makevars` and sets no compiler flags of
+its own. The NOTE does not appear on CRAN's builders. GitHub Actions sets
+`_R_CHECK_COMPILATION_FLAGS_KNOWN_` so the same NOTE is not treated as a
+check issue on this repository's runners.

--- a/man/AddiVortes-package.Rd
+++ b/man/AddiVortes-package.Rd
@@ -6,18 +6,21 @@
 \title{AddiVortes: Bayesian Additive Voronoi Tessellations for Machine Learning}
 \description{
 AddiVortes implements Bayesian Additive Voronoi Tessellation models for
-machine learning regression and non-parametric statistical modeling. This
-package provides a flexible alternative to BART (Bayesian Additive Regression
-Trees), using Voronoi tessellations instead of trees for spatial partitioning.
-The method is particularly effective for spatial data analysis, complex
-function approximation, and Bayesian regression modeling.
+machine learning regression, classification and non-parametric statistical
+modelling. This package provides a flexible alternative to BART (Bayesian
+Additive Regression Trees), using Voronoi tessellations instead of trees for
+spatial partitioning. The method is particularly effective for spatial data
+analysis, complex function approximation, and Bayesian regression and
+classification.
 }
 \details{
 Key features include:
 \itemize{
-\item Machine learning regression with Bayesian inference
+\item Machine learning regression and classification with Bayesian inference
+\item Binary and multinomial probit models with latent-variable data
+augmentation
 \item Alternative to BART using Voronoi tessellations
-\item Spatial data analysis and modeling
+\item Spatial data analysis and modelling
 \item Non-parametric regression capabilities
 \item Complex function approximation
 \item Uncertainty quantification through posterior inference
@@ -26,6 +29,16 @@ Key features include:
 \references{
 Stone, A. and Gosling, J.P. (2025). AddiVortes: (Bayesian) additive Voronoi
 tessellations. Journal of Computational and Graphical Statistics.
+
+Stone, A.J., Ogundimu, E. and Gosling, J.P. (2026). Binary AddiVortes:
+(Bayesian) Additive Voronoi Tessellations for Binary Classification with an
+application to Predicting Home Mortgage Application Outcomes.
+
+Albert, J.H. and Chib, S. (1993). Bayesian analysis of binary and
+polychotomous response data. Journal of the American Statistical Association.
+
+Kindo, B.P., Wang, H. and Peña, E.A. (2016). Multinomial probit Bayesian
+additive regression trees. Stat.
 }
 \seealso{
 \url{https://johnpaulgosling.github.io/AddiVortes/}
@@ -43,6 +56,7 @@ Authors:
 }
 \keyword{BART}
 \keyword{bayesian}
+\keyword{classification}
 \keyword{machine-learning}
 \keyword{package}
 \keyword{regression}

--- a/man/AddiVortes.Rd
+++ b/man/AddiVortes.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/AddiVortes.R
 \name{AddiVortes}
 \alias{AddiVortes}
-\title{Fit an AddiVortes regression model}
+\title{Fit an AddiVortes regression or classification model}
 \usage{
 AddiVortes(
   y,
@@ -26,23 +26,36 @@ AddiVortes(
 )
 }
 \arguments{
-\item{y}{A vector of the output values.}
+\item{y}{A vector of response values. Numeric \code{y} is treated as regression,
+except when it has exactly two unique values in \verb{\{0, 1\}}, which is
+binary classification. Factor, character and logical vectors are treated as
+classification: two levels give a binary probit model and three or more
+levels give a multinomial probit model. The first factor level (or 0 for
+numeric 0/1 responses) is the reference class. Missing values are not
+allowed.}
 
 \item{x}{A matrix or data frame of the covariates. Character and factor columns
 are treated as categorical variables and automatically converted to d-1 binary
 indicator variables via one-hot encoding (with the first level as reference).}
 
-\item{m}{The number of tessellations.}
+\item{m}{The number of tessellations. For multinomial classification this is
+the number of tessellations \strong{per latent dimension} (there are \(K-1\)
+latents for \(K\) classes).}
 
 \item{totalMCMCIter}{The number of iterations.}
 
 \item{mcmcBurnIn}{The number of burn in iterations.}
 
-\item{nu}{The degrees of freedom.}
+\item{nu}{The degrees of freedom for the inverse-gamma prior on the residual
+variance. Ignored for classification, where the latent residual variance is
+fixed at 1.}
 
-\item{q}{The quantile.}
+\item{q}{The quantile used to set the inverse-gamma prior on the residual
+variance. Ignored for classification.}
 
-\item{k}{The number of centres.}
+\item{k}{Prior scale for tessellation output values. For regression,
+\(\sigma_\mu = 0.5/(k\sqrt{m})\) on the scaled response. For classification,
+\(\sigma_\mu = 3/(k\sqrt{m})\) on the latent probit scale.}
 
 \item{sd}{The standard deviation used in centre proposals.}
 
@@ -51,7 +64,9 @@ adding a dimension.}
 
 \item{LambdaRate}{The rate of the Poisson distribution for the number of centres.}
 
-\item{InitialSigma}{The method used to calculate the initial variance.}
+\item{InitialSigma}{The method used to calculate the initial residual
+variance for regression (\code{"Linear"} or \code{"Naive"}). Ignored for
+classification.}
 
 \item{thinning}{The thinning rate.}
 
@@ -86,15 +101,16 @@ for a comparison and guidance on which to use.}
 \value{
 An AddiVortes object containing the posterior samples of the
 tessellations, dimensions and predictions, plus per-iteration trace
-statistics used by \code{traceplots()}.
+statistics used by \code{traceplots()}. Classification fits also store \code{task},
+\code{classLevels}, \code{nLatents} and in-sample accuracy.
 }
 \description{
-The AddiVortes model is a Bayesian nonparametric regression model that
-uses a tessellation to model the relationship between the covariates and
-the output values. The model uses a backfitting algorithm to sample from
-the posterior distribution of the output values for each tessellation.
-Alongside fitting details and the posterior sample, the function returns
-the RMSE value for the test samples.
+The AddiVortes model is a Bayesian nonparametric model that uses additive
+Voronoi tessellations to relate covariates to a response. For a numeric
+response the model is Gaussian regression. For a classification response
+it uses a probit link with Albert-Chib latent variables (binary) or
+independent multinomial probit latents (three or more classes). The task is
+chosen automatically from \code{y}.
 
 The function can handle multiple types of covariates, including continuous,
 spherical and categorical. Categorical covariates are automatically detected.
@@ -146,6 +162,30 @@ y_test <- x_test$x1 + ifelse(x_test$grp2 == "B", 1, 0) + rnorm(n_test, sd = 0.5)
 
 preds <- predict(fit2, x_test, showProgress = FALSE)
 test_rmse <- sqrt(mean((y_test - preds)^2))
+
+# Binary classification is selected automatically from a 0/1 or factor y
+set.seed(789)
+x_clf <- matrix(runif(80), 40, 2)
+y_clf <- factor(ifelse(x_clf[, 1] + x_clf[, 2] > 1, "yes", "no"))
+fit_clf <- AddiVortes(y_clf, x_clf, m = 8, totalMCMCIter = 80,
+                      mcmcBurnIn = 20, showProgress = FALSE)
+p_clf <- predict(fit_clf, x_clf, type = "response", showProgress = FALSE)
+cls_clf <- predict(fit_clf, x_clf, type = "class", showProgress = FALSE)
 }
 
+}
+\references{
+Stone, A. and Gosling, J.P. (2025). AddiVortes: (Bayesian) additive Voronoi
+tessellations. \emph{Journal of Computational and Graphical Statistics}.
+
+Stone, A.J., Ogundimu, E. and Gosling, J.P. (2026). Binary AddiVortes:
+(Bayesian) Additive Voronoi Tessellations for Binary Classification with an
+application to Predicting Home Mortgage Application Outcomes.
+
+Albert, J.H. and Chib, S. (1993). Bayesian analysis of binary and
+polychotomous response data. \emph{Journal of the American Statistical
+Association}, 88(422), 669–679.
+
+Kindo, B.P., Wang, H. and Peña, E.A. (2016). Multinomial probit Bayesian
+additive regression trees. \emph{Stat}, 5(1), 171–181.
 }

--- a/man/AddiVortes.Rd
+++ b/man/AddiVortes.Rd
@@ -39,8 +39,8 @@ are treated as categorical variables and automatically converted to d-1 binary
 indicator variables via one-hot encoding (with the first level as reference).}
 
 \item{m}{The number of tessellations. For multinomial classification this is
-the number of tessellations \strong{per latent dimension} (there are \(K-1\)
-latents for \(K\) classes).}
+the number of tessellations \strong{per latent dimension} (there are
+\eqn{K-1}{K-1} latents for \eqn{K}{K} classes).}
 
 \item{totalMCMCIter}{The number of iterations.}
 
@@ -54,8 +54,10 @@ fixed at 1.}
 variance. Ignored for classification.}
 
 \item{k}{Prior scale for tessellation output values. For regression,
-\(\sigma_\mu = 0.5/(k\sqrt{m})\) on the scaled response. For classification,
-\(\sigma_\mu = 3/(k\sqrt{m})\) on the latent probit scale.}
+\eqn{\sigma_\mu = 0.5/(k\sqrt{m})}{sigma_mu = 0.5/(k sqrt(m))} on the scaled
+response. For classification,
+\eqn{\sigma_\mu = 3/(k\sqrt{m})}{sigma_mu = 3/(k sqrt(m))} on the latent
+probit scale.}
 
 \item{sd}{The standard deviation used in centre proposals.}
 

--- a/man/new_AddiVortes.Rd
+++ b/man/new_AddiVortes.Rd
@@ -68,7 +68,8 @@ were present.}
 or \code{NULL} for regression.}
 
 \item{nLatents}{Number of latent probit dimensions. 1 for regression and
-binary classification; \(K-1\) for \(K\)-class multinomial models.}
+binary classification; \eqn{K-1}{K-1} for \eqn{K}{K}-class multinomial
+models.}
 
 \item{mPerLatent}{Number of tessellations per latent ensemble.}
 

--- a/man/new_AddiVortes.Rd
+++ b/man/new_AddiVortes.Rd
@@ -19,7 +19,13 @@ new_AddiVortes(
   metric_aug = "E",
   member_aug = rep(1, length(xCentres)),
   catEncoding = NULL,
-  traceStats = NULL
+  traceStats = NULL,
+  task = "regression",
+  classLevels = NULL,
+  nLatents = 1L,
+  mPerLatent = NA_integer_,
+  inSampleAccuracy = NA_real_,
+  inSampleBrier = NA_real_
 )
 }
 \arguments{
@@ -55,6 +61,22 @@ to one-hot}
 were present.}
 
 \item{traceStats}{Optional data frame of per-iteration MCMC trace statistics.}
+
+\item{task}{The modelling task: \code{"regression"}, \code{"binary"} or \code{"multinomial"}.}
+
+\item{classLevels}{Character vector of class labels for classification fits,
+or \code{NULL} for regression.}
+
+\item{nLatents}{Number of latent probit dimensions. 1 for regression and
+binary classification; \(K-1\) for \(K\)-class multinomial models.}
+
+\item{mPerLatent}{Number of tessellations per latent ensemble.}
+
+\item{inSampleAccuracy}{In-sample classification accuracy, or \code{NA} for
+regression.}
+
+\item{inSampleBrier}{In-sample Brier score for binary classification, or \code{NA}
+otherwise.}
 }
 \value{
 An object of class AddiVortes.

--- a/man/plot.AddiVortes.Rd
+++ b/man/plot.AddiVortes.Rd
@@ -18,9 +18,10 @@
 \item{x}{An object of class \code{AddiVortes}, typically the result of a
 call to \code{AddiVortes()}.}
 
-\item{x_train}{A matrix of the original training covariates.}
+\item{x_train}{A matrix or data frame of the original training covariates.}
 
-\item{y_train}{A numeric vector of the original training true outcomes.}
+\item{y_train}{The original training response. Numeric for regression;
+factor, character, logical or 0/1 numeric for classification.}
 
 \item{sigma_trace}{An optional numeric vector of sigma values from MCMC samples.
 If not provided, the method will attempt to extract the posterior error

--- a/man/predict.AddiVortes.Rd
+++ b/man/predict.AddiVortes.Rd
@@ -25,7 +25,7 @@ columns must match the original training data.}
 the mean prediction (class probabilities for classification). \code{"quantile"}
 returns the quantiles specified by \code{quantiles}. \code{"class"} returns predicted
 class labels (classification only). \code{"link"} returns the latent sum of
-tessellations \(G(x)\).}
+tessellations \eqn{G(x)}{G(x)}.}
 
 \item{quantiles}{A numeric vector of probabilities to
 compute for the predictions when \code{type = "quantile"}.}
@@ -43,11 +43,11 @@ unused).}
 }
 \value{
 If \code{type = "response"}, a numeric vector of mean predictions for regression
-or binary classification, or an \(n \times K\) probability matrix for
-multinomial classification. If \code{type = "quantile"}, a matrix of quantiles
+or binary classification, or an \eqn{n \times K}{n x K} probability matrix
+for multinomial classification. If \code{type = "quantile"}, a matrix of quantiles
 (binary/regression) or a named list of such matrices (multinomial). If
 \code{type = "class"}, a factor of predicted labels. If \code{type = "link"}, the
-latent function \(G(x)\).
+latent function \eqn{G(x)}{G(x)}.
 }
 \description{
 Predicts outcomes for new data using a fitted \code{AddiVortes} model object.
@@ -72,9 +72,9 @@ probit link with residual variance fixed at 1, so prediction intervals are
 not defined; use \code{type = "quantile"} for credible intervals on probabilities.
 
 For binary classification, \code{"response"} is the posterior mean of
-\(\Phi(G^{(s)}(x))\). For multinomial classification, class probabilities
-are estimated from independent \(N(G, I)\) latents, with the first class
-as the reference.
+\eqn{\Phi(G^{(s)}(x))}{Phi(G^(s)(x))}. For multinomial classification, class
+probabilities are estimated from independent \eqn{N(G, I)}{N(G, I)} latents,
+with the first class as the reference.
 }
 \examples{
 \donttest{

--- a/man/predict.AddiVortes.Rd
+++ b/man/predict.AddiVortes.Rd
@@ -7,7 +7,7 @@
 \method{predict}{AddiVortes}(
   object,
   newdata,
-  type = c("response", "quantile"),
+  type = c("response", "quantile", "class", "link"),
   quantiles = c(0.025, 0.975),
   interval = c("credible", "prediction"),
   showProgress = interactive(),
@@ -22,8 +22,10 @@ call to \code{AddiVortes()}.}
 columns must match the original training data.}
 
 \item{type}{The type of prediction required. The default \code{"response"} gives
-the mean prediction. The alternative \code{"quantile"} returns the quantiles
-specified by the \code{quantiles} argument.}
+the mean prediction (class probabilities for classification). \code{"quantile"}
+returns the quantiles specified by \code{quantiles}. \code{"class"} returns predicted
+class labels (classification only). \code{"link"} returns the latent sum of
+tessellations \(G(x)\).}
 
 \item{quantiles}{A numeric vector of probabilities to
 compute for the predictions when \code{type = "quantile"}.}
@@ -31,7 +33,8 @@ compute for the predictions when \code{type = "quantile"}.}
 \item{interval}{The type of interval calculation. The default \code{"credible"}
 accounts only for uncertainty in the mean (similar to \code{lm}'s confidence interval).
 The alternative \code{"prediction"} also includes the model's error variance,
-producing wider intervals (similar to \code{lm}'s prediction interval).}
+producing wider intervals (similar to \code{lm}'s prediction interval). Not used
+for classification models.}
 
 \item{showProgress}{Logical; if TRUE, a progress bar is shown during prediction.}
 
@@ -39,14 +42,18 @@ producing wider intervals (similar to \code{lm}'s prediction interval).}
 unused).}
 }
 \value{
-If \code{type = "response"}, a numeric vector of mean predictions.
-If \code{type = "quantile"}, a matrix where each row corresponds to an observation
-in \code{newdata} and each column to a quantile.
+If \code{type = "response"}, a numeric vector of mean predictions for regression
+or binary classification, or an \(n \times K\) probability matrix for
+multinomial classification. If \code{type = "quantile"}, a matrix of quantiles
+(binary/regression) or a named list of such matrices (multinomial). If
+\code{type = "class"}, a factor of predicted labels. If \code{type = "link"}, the
+latent function \(G(x)\).
 }
 \description{
 Predicts outcomes for new data using a fitted \code{AddiVortes} model object.
-It can return mean predictions, quantiles and optionally calculate the
-Root Mean Squared Error (RMSE) if true outcomes are provided.
+Regression fits return means or quantiles of the response. Classification
+fits return class probabilities, class labels, latent-scale values, or
+quantiles of the class probabilities.
 }
 \details{
 This function relies on the internal helper function \code{applyScaling_internal}
@@ -60,7 +67,14 @@ When \code{interval = "prediction"} and \code{type = "quantile"}, the function s
 additional Gaussian noise with variance equal to the sampled sigma squared
 from the posterior. This accounts for the inherent variability in individual
 predictions, not just uncertainty in the mean function. The noise is added
-in the scaled space before unscaling predictions.
+in the scaled space before unscaling predictions. Classification uses a
+probit link with residual variance fixed at 1, so prediction intervals are
+not defined; use \code{type = "quantile"} for credible intervals on probabilities.
+
+For binary classification, \code{"response"} is the posterior mean of
+\(\Phi(G^{(s)}(x))\). For multinomial classification, class probabilities
+are estimated from independent \(N(G, I)\) latents, with the first class
+as the reference.
 }
 \examples{
 \donttest{

--- a/man/predict.AddiVortes.Rd
+++ b/man/predict.AddiVortes.Rd
@@ -25,7 +25,8 @@ columns must match the original training data.}
 the mean prediction (class probabilities for classification). \code{"quantile"}
 returns the quantiles specified by \code{quantiles}. \code{"class"} returns predicted
 class labels (classification only). \code{"link"} returns the latent sum of
-tessellations \eqn{G(x)}{G(x)}.}
+tessellations \eqn{G(x)}{G(x)} on the model scale before any response
+unscaling.}
 
 \item{quantiles}{A numeric vector of probabilities to
 compute for the predictions when \code{type = "quantile"}.}
@@ -47,7 +48,8 @@ or binary classification, or an \eqn{n \times K}{n x K} probability matrix
 for multinomial classification. If \code{type = "quantile"}, a matrix of quantiles
 (binary/regression) or a named list of such matrices (multinomial). If
 \code{type = "class"}, a factor of predicted labels. If \code{type = "link"}, the
-latent function \eqn{G(x)}{G(x)}.
+latent function \eqn{G(x)}{G(x)} on the model scale before response
+unscaling.
 }
 \description{
 Predicts outcomes for new data using a fitted \code{AddiVortes} model object.
@@ -70,6 +72,10 @@ predictions, not just uncertainty in the mean function. The noise is added
 in the scaled space before unscaling predictions. Classification uses a
 probit link with residual variance fixed at 1, so prediction intervals are
 not defined; use \code{type = "quantile"} for credible intervals on probabilities.
+
+For regression, \code{"response"} unscales predictions back to the original
+response units, while \code{"link"} returns the posterior mean of the latent
+scaled function \eqn{G(x)}{G(x)}.
 
 For binary classification, \code{"response"} is the posterior mean of
 \eqn{\Phi(G^{(s)}(x))}{Phi(G^(s)(x))}. For multinomial classification, class

--- a/src/addi_vortes_code.cpp
+++ b/src/addi_vortes_code.cpp
@@ -860,6 +860,92 @@ struct FlatPosterior {
   std::vector<int> d;
 };
 
+// Sample from N(0,1) truncated to (a, +Inf). Inverse CDF when a is moderate;
+// Robert (1995) exponential rejection in the far right tail.
+static double rtnorm_std_left(double a) {
+  if (a < 0.5) {
+    double fa = pnorm(a, 0.0, 1.0, 1, 0);
+    double u = fa + unif_rand() * (1.0 - fa);
+    if (u >= 1.0) u = 1.0 - 1e-16;
+    if (u <= fa) u = 0.5 * (fa + 1.0);
+    return qnorm(u, 0.0, 1.0, 1, 0);
+  }
+  const double alpha = 0.5 * (a + sqrt(a * a + 4.0));
+  for (int it = 0; it < 10000; ++it) {
+    const double z = a + exp_rand() / alpha;
+    const double rho = exp(-0.5 * (z - alpha) * (z - alpha));
+    if (unif_rand() <= rho) return z;
+  }
+  return a;
+}
+
+// Sample from N(mu, 1) truncated to (lower, upper). Bounds may be infinite.
+static double rtruncated_normal(double mu, double lower, double upper) {
+  if (!(lower < upper)) {
+    return 0.5 * (lower + upper);
+  }
+  const bool left_inf = !std::isfinite(lower);
+  const bool right_inf = !std::isfinite(upper);
+  double z;
+  if (left_inf && right_inf) {
+    z = mu + norm_rand();
+  } else if (right_inf) {
+    z = mu + rtnorm_std_left(lower - mu);
+  } else if (left_inf) {
+    z = mu - rtnorm_std_left(-(upper - mu));
+  } else {
+    const double a = lower - mu;
+    const double b = upper - mu;
+    const double fa = pnorm(a, 0.0, 1.0, 1, 0);
+    const double fb = pnorm(b, 0.0, 1.0, 1, 0);
+    if (fb - fa < 1e-14) {
+      if (mu < lower) return lower;
+      if (mu > upper) return upper;
+      return mu;
+    }
+    double u = fa + unif_rand() * (fb - fa);
+    if (u <= 0.0 || u >= 1.0) u = 0.5 * (fa + fb);
+    z = mu + qnorm(u, 0.0, 1.0, 1, 0);
+  }
+  if (!std::isfinite(z)) {
+    z = std::min(std::max(mu, lower), upper);
+  }
+  if (z < lower) z = lower;
+  if (z > upper) z = upper;
+  return z;
+}
+
+// Gibbs update of independent probit latents given current G and class labels.
+// yClass is 0-based with 0 = reference class. zLatent is column-major n x nLatents.
+static void sample_classification_latents(
+    std::vector<double>& zLatent,
+    const std::vector<std::vector<double>>& gLatent,
+    const int* yClass, int n, int nLatents) {
+  const double inf = std::numeric_limits<double>::infinity();
+  for (int d = 0; d < nLatents; ++d) {
+    for (int obs = 0; obs < n; ++obs) {
+      const int y = yClass[obs];
+      double lower = -inf;
+      double upper = inf;
+      if (y == 0) {
+        upper = 0.0;
+      } else if (y == d + 1) {
+        lower = 0.0;
+        for (int e = 0; e < nLatents; ++e) {
+          if (e != d) {
+            const double zo = zLatent[obs + e * n];
+            if (zo > lower) lower = zo;
+          }
+        }
+      } else {
+        const int c = y - 1;
+        upper = zLatent[obs + c * n];
+      }
+      zLatent[obs + d * n] = rtruncated_normal(gLatent[d][obs], lower, upper);
+    }
+  }
+}
+
 static FlatPosterior flatten_posterior(SEXP posteriorTess_sexp,
                                        SEXP posteriorDim_sexp,
                                        SEXP posteriorPred_sexp) {
@@ -1103,7 +1189,10 @@ extern "C" {
       SEXP init_pred_sexp,
       SEXP binaryCols_sexp,
       SEXP catScaling_sexp,
-      SEXP showProgress_sexp) {
+      SEXP showProgress_sexp,
+      SEXP isClassification_sexp,
+      SEXP yClass_sexp,
+      SEXP nLatents_sexp) {
 
     const double* xScaled = REAL(xScaled_sexp);
     const double* yScaled = REAL(yScaled_sexp);
@@ -1122,6 +1211,17 @@ extern "C" {
     const double* mus = REAL(mus_sexp);
     double catScaling = REAL(catScaling_sexp)[0];
     bool showProgress = LOGICAL(showProgress_sexp)[0];
+    const bool isClassification = LOGICAL(isClassification_sexp)[0];
+    int nLatents = INTEGER(nLatents_sexp)[0];
+    if (nLatents < 1 || !isClassification) nLatents = 1;
+    const int mTotal = m * nLatents;
+    const int* yClass = nullptr;
+    if (isClassification) {
+      if (Rf_isNull(yClass_sexp) || Rf_length(yClass_sexp) != n) {
+        Rf_error("Classification MCMC requires an integer class vector of length n");
+      }
+      yClass = INTEGER(yClass_sexp);
+    }
 
     std::vector<int> metric(INTEGER(metric_sexp), INTEGER(metric_sexp) + p);
     std::vector<int> members(INTEGER(member_sexp), INTEGER(member_sexp) + p);
@@ -1174,12 +1274,12 @@ extern "C" {
     std::vector<double> x_row;
     pack_row_major(xScaled, n, p, x_row);
 
-    // Initial state
-    std::vector<std::vector<double>> tess(m);
-    std::vector<int> tess_nC(m), tess_d(m);
-    std::vector<std::vector<int>> dim_j(m);
-    std::vector<std::vector<double>> pred(m);
-    for (int j = 0; j < m; ++j) {
+    // Initial state. m is tessellations per latent; mTotal = m * nLatents.
+    std::vector<std::vector<double>> tess(mTotal);
+    std::vector<int> tess_nC(mTotal), tess_d(mTotal);
+    std::vector<std::vector<int>> dim_j(mTotal);
+    std::vector<std::vector<double>> pred(mTotal);
+    for (int j = 0; j < mTotal; ++j) {
       SEXP t_j = VECTOR_ELT(init_tess_sexp, j);
       int rows = Rf_nrows(t_j), cols = Rf_ncols(t_j);
       tess_nC[j] = rows;
@@ -1193,10 +1293,10 @@ extern "C" {
     }
 
     // Assignment caches (option 1)
-    std::vector<AssignmentCache> caches(m);
+    std::vector<AssignmentCache> caches(mTotal);
     AssignScratch assign_scratch;
     AssignmentCache prop_cache;
-    for (int j = 0; j < m; ++j) {
+    for (int j = 0; j < mTotal; ++j) {
       reassign(x_row.data(), n, p,
                tess[j].data(), tess_nC[j], tess_d[j], dim_j[j],
                AssignmentDelta::FullRecompute, 0, euclidean,
@@ -1204,11 +1304,17 @@ extern "C" {
                AssignmentCache{}, caches[j], assign_scratch);
     }
 
-    std::vector<double> sumAllTess(n, 0.0);
-    for (int j = 0; j < m; ++j) {
-      for (int obs = 0; obs < n; ++obs)
-        sumAllTess[obs] += pred[j][caches[j].assignment[obs]];
+    std::vector<std::vector<double>> gLatent(nLatents, std::vector<double>(n, 0.0));
+    for (int lat = 0; lat < nLatents; ++lat) {
+      const int j0 = lat * m;
+      const int j1 = j0 + m;
+      for (int j = j0; j < j1; ++j) {
+        for (int obs = 0; obs < n; ++obs)
+          gLatent[lat][obs] += pred[j][caches[j].assignment[obs]];
+      }
     }
+
+    std::vector<double> zLatent;
 
     int numSamples = 0;
     if (totalIter > burnIn) numSamples = (totalIter - burnIn) / thinning;
@@ -1238,126 +1344,159 @@ extern "C" {
     const int progressWidth = 40;
     int lastFilled = -1;
 
+    if (isClassification) {
+      zLatent.assign(static_cast<size_t>(n) * nLatents, 0.0);
+      for (int obs = 0; obs < n; ++obs) {
+        const int y = yClass[obs];
+        if (y == 0) {
+          for (int d = 0; d < nLatents; ++d) zLatent[obs + d * n] = -1.0;
+        } else {
+          for (int d = 0; d < nLatents; ++d)
+            zLatent[obs + d * n] = (d + 1 == y) ? 1.0 : 0.0;
+        }
+      }
+    }
+
     for (int iter = 1; iter <= totalIter; ++iter) {
       maybe_progress("MCMC", iter, totalIter, progressWidth, lastFilled, showProgress);
 
-      double sum_sq = 0.0;
-      for (int obs = 0; obs < n; ++obs) {
-        double r = yScaled[obs] - sumAllTess[obs];
-        sum_sq += r * r;
-      }
-      double shape = (nu + n) / 2.0;
-      double rate = (nu * lambda + sum_sq) / 2.0;
-      sigmaSquared = 1.0 / rgamma(shape, 1.0 / rate);
-
-      for (int j = 0; j < m; ++j) {
-        if (j == 0) {
-          for (int obs = 0; obs < n; ++obs)
-            sumAllTess[obs] -= pred[j][caches[j].assignment[obs]];
-        } else {
-          for (int obs = 0; obs < n; ++obs)
-            sumAllTess[obs] += lastTessPred[obs] - pred[j][caches[j].assignment[obs]];
+      if (!isClassification) {
+        double sum_sq = 0.0;
+        for (int obs = 0; obs < n; ++obs) {
+          double r = yScaled[obs] - gLatent[0][obs];
+          sum_sq += r * r;
         }
+        double shape = (nu + n) / 2.0;
+        double rate = (nu * lambda + sum_sq) / 2.0;
+        sigmaSquared = 1.0 / rgamma(shape, 1.0 / rate);
+      } else {
+        sample_classification_latents(zLatent, gLatent, yClass, n, nLatents);
+      }
 
-        for (int obs = 0; obs < n; ++obs)
-          R_j[obs] = yScaled[obs] - sumAllTess[obs];
+      for (int lat = 0; lat < nLatents; ++lat) {
+        std::vector<double>& sumAllTess = gLatent[lat];
+        const double* response = isClassification
+          ? (zLatent.data() + static_cast<size_t>(lat) * n)
+          : yScaled;
+        const int j0 = lat * m;
+        const int j1 = j0 + m;
 
-        ProposalResult prop = propose_internal(
-          tess[j], tess_nC[j], tess_d[j], dim_j[j],
-          p, sd, mus, metric, members, ncats, cat_index_of_col);
+        for (int j = j0; j < j1; ++j) {
+          const int jLocal = j - j0;
+          if (jLocal == 0) {
+            for (int obs = 0; obs < n; ++obs)
+              sumAllTess[obs] -= pred[j][caches[j].assignment[obs]];
+          } else {
+            for (int obs = 0; obs < n; ++obs)
+              sumAllTess[obs] += lastTessPred[obs] - pred[j][caches[j].assignment[obs]];
+          }
 
-        // Clamp binary columns via mask (option 13)
-        if (!Rf_isNull(binaryCols_sexp)) {
-          int d_star = static_cast<int>(prop.dim.size());
-          for (int di = 0; di < d_star; ++di) {
-            int g0 = prop.dim[di] - 1;
-            if (g0 >= 0 && g0 < p && is_binary[g0]) {
-              for (int row = 0; row < prop.nC; ++row) {
-                double v = prop.tess[row + di * prop.nC];
-                if (v < 0.0) v = 0.0;
-                if (v > catScaling) v = catScaling;
-                prop.tess[row + di * prop.nC] = v;
+          for (int obs = 0; obs < n; ++obs)
+            R_j[obs] = response[obs] - sumAllTess[obs];
+
+          ProposalResult prop = propose_internal(
+            tess[j], tess_nC[j], tess_d[j], dim_j[j],
+            p, sd, mus, metric, members, ncats, cat_index_of_col);
+
+          // Clamp binary columns via mask (option 13)
+          if (!Rf_isNull(binaryCols_sexp)) {
+            int d_star = static_cast<int>(prop.dim.size());
+            for (int di = 0; di < d_star; ++di) {
+              int g0 = prop.dim[di] - 1;
+              if (g0 >= 0 && g0 < p && is_binary[g0]) {
+                for (int row = 0; row < prop.nC; ++row) {
+                  double v = prop.tess[row + di * prop.nC];
+                  if (v < 0.0) v = 0.0;
+                  if (v > catScaling) v = catScaling;
+                  prop.tess[row + di * prop.nC] = v;
+                }
               }
             }
           }
-        }
 
-        reassign(x_row.data(), n, p,
-                 prop.tess.data(), prop.nC, static_cast<int>(prop.dim.size()),
-                 prop.dim, prop.delta, prop.touched, euclidean,
-                 metric_red, member_red, ncats,
-                 caches[j], prop_cache, assign_scratch);
+          reassign(x_row.data(), n, p,
+                   prop.tess.data(), prop.nC, static_cast<int>(prop.dim.size()),
+                   prop.dim, prop.delta, prop.touched, euclidean,
+                   metric_red, member_red, ncats,
+                   caches[j], prop_cache, assign_scratch);
 
-        // Option 5: one pass builds both aggregates; reused for MH and mu draw
-        aggregate_residuals_both(R_j,
-          caches[j].assignment, tess_nC[j],
-          prop_cache.assignment, prop.nC,
-          R_old, n_old, R_new, n_new);
+          // Option 5: one pass builds both aggregates; reused for MH and mu draw
+          aggregate_residuals_both(R_j,
+            caches[j].assignment, tess_nC[j],
+            prop_cache.assignment, prop.nC,
+            R_old, n_old, R_new, n_new);
 
-        bool hasEmpty = false;
-        for (int k = 0; k < prop.nC; ++k) {
-          if (n_new[k] == 0) { hasEmpty = true; break; }
-        }
+          bool hasEmpty = false;
+          for (int k = 0; k < prop.nC; ++k) {
+            if (n_new[k] == 0) { hasEmpty = true; break; }
+          }
 
-        bool accepted = false;
-        if (!hasEmpty) {
-          AcceptanceComponents acc = log_acceptance_components(
-            R_old, n_old, R_new, n_new,
-            static_cast<int>(prop.dim.size()), prop.nC,
-            sigmaSquared, sigSqMu, omega, lambdaRate, p, prop.mod);
-          accepted = (log(unif_rand()) < acc.logAlpha);
-        }
+          bool accepted = false;
+          if (!hasEmpty) {
+            AcceptanceComponents acc = log_acceptance_components(
+              R_old, n_old, R_new, n_new,
+              static_cast<int>(prop.dim.size()), prop.nC,
+              sigmaSquared, sigSqMu, omega, lambdaRate, p, prop.mod);
+            accepted = (log(unif_rand()) < acc.logAlpha);
+          }
 
-        if (accepted) {
-          tess[j] = std::move(prop.tess);
-          tess_nC[j] = prop.nC;
-          tess_d[j] = static_cast<int>(prop.dim.size());
-          dim_j[j] = std::move(prop.dim);
-          caches[j] = std::move(prop_cache);
-          sample_mu_into(R_new, n_new, sigSqMu, sigmaSquared, pred[j]);
-          for (int obs = 0; obs < n; ++obs)
-            lastTessPred[obs] = pred[j][caches[j].assignment[obs]];
-        } else {
-          sample_mu_into(R_old, n_old, sigSqMu, sigmaSquared, pred[j]);
-          for (int obs = 0; obs < n; ++obs)
-            lastTessPred[obs] = pred[j][caches[j].assignment[obs]];
-        }
+          if (accepted) {
+            tess[j] = std::move(prop.tess);
+            tess_nC[j] = prop.nC;
+            tess_d[j] = static_cast<int>(prop.dim.size());
+            dim_j[j] = std::move(prop.dim);
+            caches[j] = std::move(prop_cache);
+            sample_mu_into(R_new, n_new, sigSqMu, sigmaSquared, pred[j]);
+            for (int obs = 0; obs < n; ++obs)
+              lastTessPred[obs] = pred[j][caches[j].assignment[obs]];
+          } else {
+            sample_mu_into(R_old, n_old, sigSqMu, sigmaSquared, pred[j]);
+            for (int obs = 0; obs < n; ++obs)
+              lastTessPred[obs] = pred[j][caches[j].assignment[obs]];
+          }
 
-        if (j == m - 1) {
-          for (int obs = 0; obs < n; ++obs)
-            sumAllTess[obs] += lastTessPred[obs];
+          if (jLocal == m - 1) {
+            for (int obs = 0; obs < n; ++obs)
+              sumAllTess[obs] += lastTessPred[obs];
+          }
         }
       }
 
       double meanCenters = 0.0;
       double meanDims = 0.0;
       double retainedLogLikSum = 0.0;
-      for (int j = 0; j < m; ++j) {
+      for (int j = 0; j < mTotal; ++j) {
         meanCenters += tess_nC[j];
         meanDims += tess_d[j];
+
+        const int lat = j / m;
+        const double* response = isClassification
+          ? (zLatent.data() + static_cast<size_t>(lat) * n)
+          : yScaled;
+        const std::vector<double>& sumAllTess = gLatent[lat];
 
         R_old.assign(tess_nC[j], 0.0);
         n_old.assign(tess_nC[j], 0);
         for (int obs = 0; obs < n; ++obs) {
           int cell = caches[j].assignment[obs];
           double tessContribution = pred[j][cell];
-          double r = yScaled[obs] - (sumAllTess[obs] - tessContribution);
+          double r = response[obs] - (sumAllTess[obs] - tessContribution);
           R_old[cell] += r;
           n_old[cell]++;
         }
         retainedLogLikSum += tessellation_log_likelihood_component(
           R_old, n_old, sigmaSquared, sigSqMu);
       }
-      meanCenters /= m;
-      meanDims /= m;
+      meanCenters /= mTotal;
+      meanDims /= mTotal;
 
       double sdCenters = 0.0;
-      if (m > 1) {
-        for (int j = 0; j < m; ++j) {
+      if (mTotal > 1) {
+        for (int j = 0; j < mTotal; ++j) {
           double diff = tess_nC[j] - meanCenters;
           sdCenters += diff * diff;
         }
-        sdCenters = sqrt(sdCenters / (m - 1));
+        sdCenters = sqrt(sdCenters / (mTotal - 1));
       }
 
       int traceIdx = iter - 1;
@@ -1366,16 +1505,16 @@ extern "C" {
       REAL(outTraceAvgCenters)[traceIdx] = meanCenters;
       REAL(outTraceSdCenters)[traceIdx] = sdCenters;
       REAL(outTraceAvgDims)[traceIdx] = meanDims;
-      REAL(outTraceLogLik)[traceIdx] = retainedLogLikSum / m;
+      REAL(outTraceLogLik)[traceIdx] = retainedLogLikSum / mTotal;
 
       if (iter > burnIn && (iter - burnIn) % thinning == 0) {
         for (int obs = 0; obs < n; ++obs)
-          predictionMatrix[obs + storageIdx * n] = sumAllTess[obs];
+          predictionMatrix[obs + storageIdx * n] = gLatent[0][obs];
 
         StoredDraw draw;
         draw.sigma = sigmaSquared;
-        draw.tessellations.resize(m);
-        for (int j = 0; j < m; ++j) {
+        draw.tessellations.resize(mTotal);
+        for (int j = 0; j < mTotal; ++j) {
           StoredTess& st = draw.tessellations[j];
           st.nC = tess_nC[j];
           st.d = tess_d[j];
@@ -1391,7 +1530,7 @@ extern "C" {
     PutRNGstate();
 
     // Pack deferred posterior into R lists (option 8)
-    SEXP packed = PROTECT(pack_posterior_lists(stored, m));
+    SEXP packed = PROTECT(pack_posterior_lists(stored, mTotal));
     SEXP outTess = VECTOR_ELT(packed, 0);
     SEXP outDim = VECTOR_ELT(packed, 1);
     SEXP outPred = VECTOR_ELT(packed, 2);

--- a/src/init.c
+++ b/src/init.c
@@ -9,14 +9,15 @@ extern SEXP calculate_residuals_cpp(SEXP, SEXP, SEXP, SEXP, SEXP);
 //extern SEXP propose_tessellation_cpp(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP addi_vortes_mcmc_cpp(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP,
                                   SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP,
-                                  SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+                                  SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP,
+                                  SEXP, SEXP, SEXP);
 extern SEXP addi_vortes_predict_cpp(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"knnx_index_cpp",             (DL_FUNC) &knnx_index_cpp,             5},
   {"calculate_residuals_cpp",    (DL_FUNC) &calculate_residuals_cpp,    5},
   //{"propose_tessellation_cpp",   (DL_FUNC) &propose_tessellation_cpp,   8},
-  {"addi_vortes_mcmc_cpp",       (DL_FUNC) &addi_vortes_mcmc_cpp,      21},
+  {"addi_vortes_mcmc_cpp",       (DL_FUNC) &addi_vortes_mcmc_cpp,      24},
   {"addi_vortes_predict_cpp",    (DL_FUNC) &addi_vortes_predict_cpp,    7},
   {NULL, NULL, 0}
 };

--- a/tests/testthat/test-CRAN-smoke.R
+++ b/tests/testthat/test-CRAN-smoke.R
@@ -24,3 +24,18 @@ test_that("predict returns correct dimensions", {
   preds <- predict(fit, X_new, showProgress = FALSE)
   expect_length(preds, 5)
 })
+
+test_that("binary classification smoke fit returns probabilities", {
+  withr::local_seed(3)
+  X <- matrix(rnorm(50), 10, 5)
+  Y <- as.integer(X[, 1] > 0)
+  fit <- AddiVortes(Y, X,
+    m = 3, totalMCMCIter = 20, mcmcBurnIn = 5,
+    showProgress = FALSE
+  )
+  expect_s3_class(fit, "AddiVortes")
+  expect_equal(fit$task, "binary")
+  preds <- predict(fit, X, type = "response", showProgress = FALSE)
+  expect_length(preds, 10)
+  expect_true(all(preds >= 0 & preds <= 1))
+})

--- a/tests/testthat/test-classification.R
+++ b/tests/testthat/test-classification.R
@@ -1,0 +1,139 @@
+# Tests for classification: task detection, binary and multinomial probit fits.
+
+test_that("infer_response_type_internal detects regression and classification", {
+  expect_equal(infer_response_type_internal(rnorm(10))$task, "regression")
+  expect_equal(infer_response_type_internal(c(0, 1, 0, 1))$task, "binary")
+  expect_equal(infer_response_type_internal(c(0L, 1L, 0L))$classLevels, c("0", "1"))
+  expect_equal(infer_response_type_internal(c(0, 1, 2))$task, "regression")
+  expect_equal(infer_response_type_internal(factor(c("a", "b", "a")))$task, "binary")
+  expect_equal(infer_response_type_internal(factor(c("a", "b", "c")))$task, "multinomial")
+  expect_equal(infer_response_type_internal(c("yes", "no", "yes"))$task, "binary")
+  expect_equal(infer_response_type_internal(c(TRUE, FALSE, TRUE))$task, "binary")
+  expect_equal(infer_response_type_internal(c(TRUE, FALSE))$nLatents, 1L)
+  expect_equal(infer_response_type_internal(factor(c("a", "b", "c")))$nLatents, 2L)
+})
+
+test_that("infer_response_type_internal rejects invalid responses", {
+  expect_error(infer_response_type_internal(c(1, NA, 0)), "missing")
+  expect_error(infer_response_type_internal(factor("only")), "at least two")
+  expect_error(infer_response_type_internal(character(0)), "length")
+})
+
+test_that("AddiVortes stores the detected task on the fitted object", {
+  skip_on_cran()
+  withr::local_seed(11)
+  x <- matrix(rnorm(80), 20, 4)
+  fit_reg <- AddiVortes(rnorm(20), x, m = 3, totalMCMCIter = 20,
+                        mcmcBurnIn = 5, showProgress = FALSE)
+  expect_equal(fit_reg$task, "regression")
+
+  y_bin <- as.integer(x[, 1] > 0)
+  fit_bin <- AddiVortes(y_bin, x, m = 3, totalMCMCIter = 20,
+                        mcmcBurnIn = 5, showProgress = FALSE)
+  expect_equal(fit_bin$task, "binary")
+  expect_equal(fit_bin$classLevels, c("0", "1"))
+  expect_equal(fit_bin$nLatents, 1L)
+})
+
+test_that("binary classification probabilities are in [0, 1] and beat chance", {
+  skip_on_cran()
+  withr::local_seed(42)
+  n <- 80
+  x <- matrix(runif(n * 2), n, 2)
+  y <- as.integer(x[, 1] + x[, 2] > 1)
+  fit <- AddiVortes(y, x, m = 8, totalMCMCIter = 80, mcmcBurnIn = 20,
+                    showProgress = FALSE)
+  expect_equal(fit$task, "binary")
+  p <- predict(fit, x, type = "response", showProgress = FALSE)
+  expect_length(p, n)
+  expect_true(all(p >= 0 & p <= 1))
+  cls <- predict(fit, x, type = "class", showProgress = FALSE)
+  expect_s3_class(cls, "factor")
+  expect_equal(levels(cls), c("0", "1"))
+  expect_gt(mean(as.character(cls) == as.character(y)), 0.7)
+  expect_gt(fit$inSampleAccuracy, 0.7)
+  expect_true(is.finite(fit$inSampleBrier))
+  q <- predict(fit, x, type = "quantile", quantiles = c(0.1, 0.9),
+               showProgress = FALSE)
+  expect_equal(dim(q), c(n, 2))
+  expect_true(all(q[, 1] <= q[, 2]))
+  link <- predict(fit, x, type = "link", showProgress = FALSE)
+  expect_length(link, n)
+})
+
+test_that("binary classification works with a two-level factor", {
+  skip_on_cran()
+  withr::local_seed(7)
+  n <- 60
+  x <- matrix(rnorm(n * 3), n, 3)
+  y <- factor(ifelse(x[, 1] > 0, "yes", "no"), levels = c("no", "yes"))
+  fit <- AddiVortes(y, x, m = 6, totalMCMCIter = 60, mcmcBurnIn = 15,
+                    showProgress = FALSE)
+  expect_equal(fit$task, "binary")
+  expect_equal(fit$classLevels, c("no", "yes"))
+  cls <- predict(fit, x, type = "class", showProgress = FALSE)
+  expect_equal(levels(cls), c("no", "yes"))
+  expect_gt(mean(cls == y), 0.65)
+})
+
+test_that("multinomial classification returns probabilities that sum to 1", {
+  skip_on_cran()
+  withr::local_seed(99)
+  n <- 75
+  x <- matrix(rnorm(n * 2), n, 2)
+  y <- factor(ifelse(x[, 1] < -0.4, "A", ifelse(x[, 1] > 0.4, "C", "B")))
+  fit <- AddiVortes(y, x, m = 5, totalMCMCIter = 50, mcmcBurnIn = 15,
+                    showProgress = FALSE)
+  expect_equal(fit$task, "multinomial")
+  expect_equal(fit$nLatents, 2L)
+  expect_equal(fit$mPerLatent, 5L)
+  expect_equal(length(fit$posteriorTess[[1]]), 10L)
+  p <- predict(fit, x, type = "response", showProgress = FALSE)
+  expect_equal(ncol(p), 3)
+  expect_equal(colnames(p), levels(y))
+  expect_equal(rowSums(p), rep(1, n), tolerance = 1e-8)
+  expect_true(all(p >= 0 & p <= 1))
+  cls <- predict(fit, x, type = "class", showProgress = FALSE)
+  expect_equal(levels(cls), levels(y))
+  expect_gt(mean(cls == y), 1 / 3)
+  expect_gt(fit$inSampleAccuracy, 1 / 3)
+  link <- predict(fit, x, type = "link", showProgress = FALSE)
+  expect_equal(dim(link), c(n, 2))
+})
+
+test_that("type = 'class' errors on a regression fit", {
+  skip_on_cran()
+  withr::local_seed(3)
+  x <- matrix(rnorm(40), 10, 4)
+  fit <- AddiVortes(rnorm(10), x, m = 3, totalMCMCIter = 15,
+                    mcmcBurnIn = 5, showProgress = FALSE)
+  expect_error(
+    predict(fit, x, type = "class", showProgress = FALSE),
+    "only valid for classification"
+  )
+})
+
+test_that("prediction intervals are rejected for classification", {
+  skip_on_cran()
+  withr::local_seed(4)
+  x <- matrix(rnorm(40), 10, 4)
+  y <- as.integer(x[, 1] > 0)
+  fit <- AddiVortes(y, x, m = 3, totalMCMCIter = 15, mcmcBurnIn = 5,
+                    showProgress = FALSE)
+  expect_error(
+    predict(fit, x, type = "quantile", interval = "prediction",
+            showProgress = FALSE),
+    "Prediction intervals are not used"
+  )
+})
+
+test_that("print mentions classification for a binary fit", {
+  skip_on_cran()
+  withr::local_seed(5)
+  x <- matrix(rnorm(40), 10, 4)
+  y <- as.integer(x[, 1] > 0)
+  fit <- AddiVortes(y, x, m = 3, totalMCMCIter = 15, mcmcBurnIn = 5,
+                    showProgress = FALSE)
+  expect_output(print(fit), "Binary Classification")
+  expect_output(print(fit), "In-sample accuracy")
+})

--- a/tests/testthat/test-classification.R
+++ b/tests/testthat/test-classification.R
@@ -61,6 +61,18 @@ test_that("binary classification probabilities are in [0, 1] and beat chance", {
   expect_length(link, n)
 })
 
+test_that("regression link predictions stay on the latent model scale", {
+  skip_on_cran()
+  withr::local_seed(21)
+  x <- matrix(rnorm(80), 20, 4)
+  y <- 10 + 4 * x[, 1] - 2 * x[, 2] + rnorm(20, sd = 0.2)
+  fit <- AddiVortes(y, x, m = 4, totalMCMCIter = 30, mcmcBurnIn = 10,
+                    showProgress = FALSE)
+  response <- predict(fit, x, type = "response", showProgress = FALSE)
+  link <- predict(fit, x, type = "link", showProgress = FALSE)
+  expect_equal(link, (response - fit$yCentre) / fit$yRange)
+})
+
 test_that("binary classification works with a two-level factor", {
   skip_on_cran()
   withr::local_seed(7)
@@ -99,6 +111,23 @@ test_that("multinomial classification returns probabilities that sum to 1", {
   expect_gt(fit$inSampleAccuracy, 1 / 3)
   link <- predict(fit, x, type = "link", showProgress = FALSE)
   expect_equal(dim(link), c(n, 2))
+})
+
+test_that("binary diagnostic plots accept numeric 0/1 responses", {
+  skip_on_cran()
+  withr::local_seed(8)
+  n <- 40
+  x <- matrix(rnorm(n * 3), n, 3)
+  y <- as.integer(x[, 1] + x[, 2] > 0)
+  fit <- AddiVortes(y, x, m = 4, totalMCMCIter = 30, mcmcBurnIn = 10,
+                    showProgress = FALSE)
+  plot_file <- tempfile(fileext = ".pdf")
+  grDevices::pdf(plot_file)
+  on.exit({
+    grDevices::dev.off()
+    unlink(plot_file)
+  }, add = TRUE)
+  expect_silent(plot(fit, x_train = x, y_train = y, which = c(1, 4)))
 })
 
 test_that("type = 'class' errors on a regression fit", {

--- a/vignettes/classification.Rmd
+++ b/vignettes/classification.Rmd
@@ -53,9 +53,9 @@ y <- factor(ifelse(x$x1 + x$x2 > 0, "active", "inactive"),
 
 fit_bin <- AddiVortes(
   y, x,
-  m = 20,
-  totalMCMCIter = 150,
-  mcmcBurnIn = 50,
+  m = 200,
+  totalMCMCIter = 2000,
+  mcmcBurnIn = 200,
   showProgress = FALSE
 )
 
@@ -106,9 +106,9 @@ y3 <- cut(x3$x1, breaks = c(-Inf, -0.5, 0.5, Inf), labels = c("low", "mid", "hig
 
 fit_multi <- AddiVortes(
   y3, x3,
-  m = 12,
-  totalMCMCIter = 120,
-  mcmcBurnIn = 40,
+  m = 200,
+  totalMCMCIter = 2000,
+  mcmcBurnIn = 200,
   showProgress = FALSE
 )
 

--- a/vignettes/classification.Rmd
+++ b/vignettes/classification.Rmd
@@ -1,0 +1,143 @@
+---
+title: "Classification with AddiVortes"
+author: "John Paul Gosling and Adam Stone"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Classification with AddiVortes}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 6,
+  fig.height = 4.5,
+  fig.align = "center"
+)
+```
+
+This vignette shows how `AddiVortes()` fits **binary** and **multi-category** classification models. The task is chosen automatically from the response `y`. Binary classification uses a probit link with Albert-Chib latent variables. Multi-category classification uses the same idea with \(K-1\) independent latent ensembles (the first class is the reference level).
+
+```{r, message=FALSE, warning=FALSE}
+library(AddiVortes)
+```
+
+## How the response is interpreted
+
+`AddiVortes()` looks only at `y`:
+
+- A **factor**, **character** or **logical** vector is classification. Two levels give a binary model; three or more give a multinomial model.
+- A **numeric** vector with exactly two unique values in `{0, 1}` is binary classification (1 is the event class).
+- Any other numeric vector is Gaussian regression, as in previous versions of the package.
+
+The first factor level is the reference class, matching `glm()`. For numeric 0/1 data, 0 is the reference. Character vectors are converted with `factor()`, so levels are alphabetical.
+
+Missing values in `y` are not allowed, and a classification response must have at least two classes.
+
+## Binary classification
+
+We simulate a two-dimensional problem whose labels follow a simple linear boundary.
+
+```{r}
+set.seed(2026)
+n <- 120
+x <- data.frame(
+  x1 = runif(n, -1, 1),
+  x2 = runif(n, -1, 1)
+)
+y <- factor(ifelse(x$x1 + x$x2 > 0, "active", "inactive"),
+            levels = c("inactive", "active"))
+
+fit_bin <- AddiVortes(
+  y, x,
+  m = 20,
+  totalMCMCIter = 150,
+  mcmcBurnIn = 50,
+  showProgress = FALSE
+)
+
+fit_bin$task
+fit_bin$classLevels
+fit_bin$inSampleAccuracy
+```
+
+`predict(..., type = "response")` returns the posterior mean of \(\Phi(G(x))\), the probability of the event class (`active` here). `type = "class"` returns labels, and `type = "quantile"` gives credible intervals for those probabilities.
+
+```{r}
+p_hat <- predict(fit_bin, x, type = "response", showProgress = FALSE)
+y_hat <- predict(fit_bin, x, type = "class", showProgress = FALSE)
+p_int <- predict(fit_bin, x,
+  type = "quantile",
+  quantiles = c(0.05, 0.95),
+  showProgress = FALSE
+)
+
+mean(y_hat == y)
+range(p_hat)
+head(cbind(prob = round(p_hat, 3), lower = round(p_int[, 1], 3),
+           upper = round(p_int[, 2], 3), class = as.character(y_hat)))
+```
+
+Observations with probability near 0.5 are the most uncertain. The 90% intervals typically cover 0.5 for those points.
+
+```{r}
+plot(p_hat, as.integer(y) - 1,
+     xlab = "Predicted P(active)",
+     ylab = "Observed class",
+     pch = 19, col = "steelblue")
+abline(v = 0.5, lty = 2, col = "grey40")
+```
+
+## Multi-category classification
+
+With three or more classes, AddiVortes fits \(K-1\) latent ensembles. The argument `m` is the number of tessellations **per latent**, so a three-class model with `m = 15` uses 30 tessellations in total.
+
+```{r}
+set.seed(2026)
+n3 <- 90
+x3 <- data.frame(
+  x1 = rnorm(n3),
+  x2 = rnorm(n3)
+)
+y3 <- cut(x3$x1, breaks = c(-Inf, -0.5, 0.5, Inf), labels = c("low", "mid", "high"))
+
+fit_multi <- AddiVortes(
+  y3, x3,
+  m = 12,
+  totalMCMCIter = 120,
+  mcmcBurnIn = 40,
+  showProgress = FALSE
+)
+
+fit_multi$task
+fit_multi$nLatents
+fit_multi$inSampleAccuracy
+```
+
+`type = "response"` is now an \(n \times K\) matrix of class probabilities. Rows sum to 1. `type = "class"` returns the class with the largest probability.
+
+```{r}
+p3 <- predict(fit_multi, x3, type = "response", showProgress = FALSE)
+cls3 <- predict(fit_multi, x3, type = "class", showProgress = FALSE)
+
+head(round(p3, 3))
+mean(abs(rowSums(p3) - 1) < 1e-8)
+table(predicted = cls3, observed = y3)
+```
+
+## Notes on the classification prior
+
+On the latent probit scale the residual variance is fixed at \(\sigma = 1\), so `nu`, `q` and `InitialSigma` are ignored. Cell means use
+
+\[
+\sigma_\mu = \frac{3}{k\sqrt{m}},
+\]
+
+which keeps \(G(x)\) typically inside \((-3, 3)\) and shrinks class probabilities towards 0.5 (or towards equal class probabilities in the multinomial case). The default `k = 3` is a reasonable starting point.
+
+The response itself is not scaled. Covariates are still centred and scaled exactly as in regression.
+
+For further details of the binary model see Stone, Ogundimu and Gosling (2026). The multi-category construction follows the latent-utility setup of Kindo, Wang and Peña (2016), with independent latents (\(\Sigma = I\)).

--- a/vignettes/prediction.Rmd
+++ b/vignettes/prediction.Rmd
@@ -90,6 +90,12 @@ preds <- predict(AModel, testX,
   showProgress = FALSE
 )
 
+# Predict the latent sum of tessellations on the model scale
+preds_link <- predict(AModel, testX,
+  type = "link",
+  showProgress = FALSE
+)
+
 # Predict the 90% credible interval (from 0.05 to 0.95 quantiles)
 # By default, this uses interval = "credible" which only accounts for
 # uncertainty in the mean function
@@ -105,6 +111,8 @@ preds_q <- predict(AModel, testX,
 #                         interval = "prediction",
 #                         showProgress = FALSE)
 ```
+
+`type = "response"` returns predictions in the original response units. `type = "link"` returns the latent model-scale function \(G(x)\) before that final unscaling step.
 
 ### 4. Visualising Prediction Performance
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #91.

`AddiVortes()` now fits classification as well as regression, choosing the task from `y`:

- Factor, character or logical responses are classification (two levels: binary; three or more: multinomial).
- Numeric 0/1 responses are binary classification.
- Any other numeric response remains Gaussian regression.

Binary classification follows the Albert-Chib latent-variable probit model in the attached paper. Multi-category classification uses \(K-1\) independent latent ensembles (identity covariance), with the first class as the reference level. On the latent scale \(\sigma = 1\) is fixed and cell means use \(\sigma_\mu = 3/(k\sqrt{m})\). The regression MCMC path is unchanged (Friedman golden tests still pass).

`predict()` gains `type = "class"` and `type = "link"`. For classification, `type = "response"` returns class probabilities and `type = "quantile"` returns credible intervals on those probabilities.

A classification vignette covers automatic task detection, binary probabilities and intervals, and multi-category probability matrices. Tests cover detection, both classification tasks, and a CRAN smoke fit.

Package version is 1.0.0.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e55e5db0-49b3-486d-a905-9c334dab9341?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e55e5db0-49b3-486d-a905-9c334dab9341&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

